### PR TITLE
Add ingestion and consent review workflow

### DIFF
--- a/app/app/Http/Controllers/Api/IngestionController.php
+++ b/app/app/Http/Controllers/Api/IngestionController.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Consent;
+use App\Models\Document;
+use App\Support\Ingestion\PiiScrubber;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+
+class IngestionController extends Controller
+{
+    /**
+     * Ingest a text document.
+     */
+    public function ingestText(Request $request, PiiScrubber $scrubber): JsonResponse
+    {
+        $validated = $request->validate([
+            'source' => ['required', 'string', 'max:255'],
+            'text' => ['required', 'string'],
+            'consent_scope' => ['required', 'string', 'max:255'],
+            'tags' => ['sometimes', 'array'],
+            'tags.*' => ['string', 'max:100'],
+            'metadata' => ['sometimes', 'array'],
+            'retention_class' => ['nullable', 'string', 'max:255'],
+            'bypass_pii_scrub' => ['sometimes', 'boolean'],
+        ]);
+
+        $user = $request->user();
+        $bypass = (bool) ($validated['bypass_pii_scrub'] ?? false);
+
+        if ($bypass && (! $user || ! $user->hasRole('owner'))) {
+            abort(Response::HTTP_FORBIDDEN, 'Only owners may bypass PII scrubbing.');
+        }
+
+        $text = $validated['text'];
+        $sanitized = $bypass ? $text : $scrubber->scrub($text);
+
+        $document = $this->storeDocument(
+            type: 'text',
+            source: $validated['source'],
+            consentScope: $validated['consent_scope'],
+            retentionClass: $validated['retention_class'] ?? null,
+            tags: $validated['tags'] ?? [],
+            metadata: $validated['metadata'] ?? [],
+            mimeType: 'text/plain',
+            originalFilename: null,
+            originalContents: $text,
+            sanitizedContent: $sanitized,
+            scrubbed: ! $bypass,
+            submittedBy: $user?->id
+        );
+
+        return response()->json([
+            'document_id' => $document->id,
+            'status' => $document->status,
+            'pii_scrubbed' => $document->pii_scrubbed,
+            'sanitized_preview' => $document->sanitized_content !== null
+                ? Str::limit($document->sanitized_content, 400)
+                : null,
+        ], Response::HTTP_ACCEPTED);
+    }
+
+    /**
+     * Ingest a file document (PDF or audio).
+     */
+    public function ingestFile(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'source' => ['required', 'string', 'max:255'],
+            'file' => ['required', 'file', 'max:20480', 'mimetypes:application/pdf,audio/mpeg,audio/wav,audio/wave,audio/x-wav,audio/flac,audio/x-flac,audio/ogg,audio/webm,audio/opus'],
+            'consent_scope' => ['required', 'string', 'max:255'],
+            'tags' => ['sometimes', 'array'],
+            'tags.*' => ['string', 'max:100'],
+            'metadata' => ['sometimes', 'array'],
+            'retention_class' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        $file = $validated['file'];
+        $user = $request->user();
+        $metadata = $validated['metadata'] ?? [];
+        $metadata['size'] = $file->getSize();
+
+        $contents = file_get_contents($file->getRealPath());
+
+        if ($contents === false) {
+            abort(Response::HTTP_INTERNAL_SERVER_ERROR, 'Unable to read uploaded file.');
+        }
+
+        $document = $this->storeDocument(
+            type: 'file',
+            source: $validated['source'],
+            consentScope: $validated['consent_scope'],
+            retentionClass: $validated['retention_class'] ?? null,
+            tags: $validated['tags'] ?? [],
+            metadata: $metadata,
+            mimeType: $file->getClientMimeType(),
+            originalFilename: $file->getClientOriginalName(),
+            originalContents: $contents,
+            sanitizedContent: null,
+            scrubbed: false,
+            submittedBy: $user?->id
+        );
+
+        return response()->json([
+            'document_id' => $document->id,
+            'status' => $document->status,
+        ], Response::HTTP_ACCEPTED);
+    }
+
+    /**
+     * Delete a document and revoke its consent.
+     */
+    public function destroyDocument(Document $document): JsonResponse
+    {
+        $this->removeDocumentFromStorage($document);
+
+        $document->status = 'deleted';
+        $document->approved_at = null;
+        $document->rejected_at = null;
+        $document->rejection_reason = null;
+        $document->reviewed_by = null;
+        $document->save();
+        $document->delete();
+
+        $document->consents()->update([
+            'status' => 'revoked',
+            'revoked_at' => now(),
+        ]);
+
+        return response()->json([
+            'status' => 'deleted',
+            'document_id' => $document->id,
+        ]);
+    }
+
+    /**
+     * Delete all documents by source.
+     */
+    public function destroyBySource(string $source): JsonResponse
+    {
+        $documents = Document::where('source', $source)->get();
+        $count = 0;
+
+        foreach ($documents as $document) {
+            $this->removeDocumentFromStorage($document);
+            $document->status = 'deleted';
+            $document->approved_at = null;
+            $document->rejected_at = null;
+            $document->rejection_reason = null;
+            $document->reviewed_by = null;
+            $document->save();
+            $document->delete();
+            $document->consents()->update([
+                'status' => 'revoked',
+                'revoked_at' => now(),
+            ]);
+            $count++;
+        }
+
+        return response()->json([
+            'status' => 'deleted',
+            'source' => $source,
+            'documents_removed' => $count,
+        ]);
+    }
+
+    private function storeDocument(
+        string $type,
+        string $source,
+        string $consentScope,
+        ?string $retentionClass,
+        array $tags,
+        array $metadata,
+        ?string $mimeType,
+        ?string $originalFilename,
+        string $originalContents,
+        ?string $sanitizedContent,
+        bool $scrubbed,
+        ?int $submittedBy
+    ): Document {
+        $documentId = (string) Str::uuid();
+        $datePrefix = now()->format('Y/m/d');
+        $directory = "sources/{$source}/{$datePrefix}/{$documentId}";
+        $extension = $this->guessExtension($type, $mimeType, $originalFilename);
+        $filename = 'original'.($extension ? ".{$extension}" : '');
+        $storagePath = "{$directory}/{$filename}";
+
+        Storage::disk('minio')->put($storagePath, $originalContents);
+
+        $document = Document::create([
+            'id' => $documentId,
+            'type' => $type,
+            'source' => $source,
+            'status' => 'pending',
+            'sha256' => hash('sha256', $originalContents),
+            'storage_disk' => 'minio',
+            'storage_path' => $storagePath,
+            'original_filename' => $originalFilename,
+            'mime_type' => $mimeType,
+            'metadata' => $metadata,
+            'tags' => $tags,
+            'retention_class' => $retentionClass,
+            'consent_scope' => $consentScope,
+            'pii_scrubbed' => $scrubbed,
+            'sanitized_content' => $sanitizedContent,
+            'submitted_by' => $submittedBy,
+        ]);
+
+        Consent::updateOrCreate(
+            ['source' => $source, 'document_id' => $document->id],
+            [
+                'user_id' => $submittedBy,
+                'scope' => $consentScope,
+                'status' => 'pending',
+            ]
+        );
+
+        return $document;
+    }
+
+    private function guessExtension(string $type, ?string $mime, ?string $originalFilename): ?string
+    {
+        if ($originalFilename) {
+            $extension = pathinfo($originalFilename, PATHINFO_EXTENSION);
+            if ($extension) {
+                return strtolower($extension);
+            }
+        }
+
+        if ($type === 'text') {
+            return 'txt';
+        }
+
+        return match ($mime) {
+            'application/pdf' => 'pdf',
+            'audio/mpeg' => 'mp3',
+            'audio/wav', 'audio/wave', 'audio/x-wav' => 'wav',
+            'audio/flac', 'audio/x-flac' => 'flac',
+            'audio/ogg', 'audio/webm', 'audio/opus' => 'ogg',
+            default => null,
+        };
+    }
+
+    private function removeDocumentFromStorage(Document $document): void
+    {
+        if ($document->storage_path) {
+            Storage::disk($document->storage_disk)->delete($document->storage_path);
+        }
+    }
+}

--- a/app/app/Http/Controllers/ReviewDocumentController.php
+++ b/app/app/Http/Controllers/ReviewDocumentController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Document;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ReviewDocumentController extends Controller
+{
+    /**
+     * Display the review queue.
+     */
+    public function index(Request $request): View
+    {
+        $documents = Document::where('status', 'pending')
+            ->orderByDesc('created_at')
+            ->paginate(20);
+
+        return view('review.documents.index', [
+            'documents' => $documents,
+        ]);
+    }
+
+    /**
+     * Approve a document.
+     */
+    public function approve(Request $request, Document $document): RedirectResponse
+    {
+        $this->authorizeReview($document);
+
+        $validated = $request->validate([
+            'notes' => ['nullable', 'string', 'max:1000'],
+        ]);
+
+        $document->status = 'approved';
+        $document->approved_at = now();
+        $document->rejected_at = null;
+        $document->rejection_reason = null;
+        $document->reviewed_by = $request->user()?->id;
+        $document->save();
+
+        $document->consents()->update([
+            'status' => 'approved',
+            'notes' => $validated['notes'] ?? null,
+            'granted_at' => now(),
+        ]);
+
+        return redirect()
+            ->route('review.documents.index')
+            ->with('status', 'Document approved.');
+    }
+
+    /**
+     * Reject a document.
+     */
+    public function reject(Request $request, Document $document): RedirectResponse
+    {
+        $this->authorizeReview($document);
+
+        $validated = $request->validate([
+            'reason' => ['required', 'string', 'max:1000'],
+        ]);
+
+        $document->status = 'rejected';
+        $document->approved_at = null;
+        $document->rejected_at = now();
+        $document->rejection_reason = $validated['reason'];
+        $document->reviewed_by = $request->user()?->id;
+        $document->save();
+
+        $document->consents()->update([
+            'status' => 'rejected',
+            'notes' => $validated['reason'],
+            'granted_at' => null,
+        ]);
+
+        return redirect()
+            ->route('review.documents.index')
+            ->with('status', 'Document rejected.');
+    }
+
+    private function authorizeReview(Document $document): void
+    {
+        if ($document->status !== 'pending') {
+            abort(Response::HTTP_CONFLICT, 'Document is not pending review.');
+        }
+    }
+}

--- a/app/app/Models/Consent.php
+++ b/app/app/Models/Consent.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Consent extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'user_id',
+        'document_id',
+        'source',
+        'scope',
+        'status',
+        'notes',
+        'granted_at',
+        'revoked_at',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'granted_at' => 'datetime',
+            'revoked_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * Document this consent is tied to.
+     */
+    public function document(): BelongsTo
+    {
+        return $this->belongsTo(Document::class);
+    }
+
+    /**
+     * User that granted consent.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/app/Models/Document.php
+++ b/app/app/Models/Document.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
+
+class Document extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     */
+    public $incrementing = false;
+
+    /**
+     * The data type of the primary key ID.
+     */
+    protected $keyType = 'string';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'id',
+        'source',
+        'type',
+        'status',
+        'sha256',
+        'storage_disk',
+        'storage_path',
+        'original_filename',
+        'mime_type',
+        'metadata',
+        'tags',
+        'retention_class',
+        'consent_scope',
+        'pii_scrubbed',
+        'sanitized_content',
+        'rejection_reason',
+        'approved_at',
+        'rejected_at',
+        'submitted_by',
+        'reviewed_by',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'metadata' => 'array',
+            'tags' => 'array',
+            'pii_scrubbed' => 'boolean',
+            'approved_at' => 'datetime',
+            'rejected_at' => 'datetime',
+            'deleted_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * Boot the model.
+     */
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::creating(function (self $model): void {
+            if (! $model->getKey()) {
+                $model->setAttribute($model->getKeyName(), (string) Str::uuid());
+            }
+        });
+    }
+
+    /**
+     * Get the user that submitted the document.
+     */
+    public function submitter(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'submitted_by');
+    }
+
+    /**
+     * Get the user that reviewed the document.
+     */
+    public function reviewer(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'reviewed_by');
+    }
+
+    /**
+     * Get consents associated with the document.
+     */
+    public function consents(): HasMany
+    {
+        return $this->hasMany(Consent::class);
+    }
+}

--- a/app/app/Support/Ingestion/PiiScrubber.php
+++ b/app/app/Support/Ingestion/PiiScrubber.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Support\Ingestion;
+
+class PiiScrubber
+{
+    /**
+     * Scrub basic PII patterns from the given text.
+     */
+    public function scrub(string $text): string
+    {
+        $scrubbed = $this->scrubEmails($text);
+        $scrubbed = $this->scrubPhoneNumbers($scrubbed);
+
+        return $scrubbed;
+    }
+
+    private function scrubEmails(string $text): string
+    {
+        $pattern = '/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i';
+
+        return (string) preg_replace($pattern, '[REDACTED:EMAIL]', $text);
+    }
+
+    private function scrubPhoneNumbers(string $text): string
+    {
+        $pattern = '/\b(?:\+?\d{1,3}[\s.-]?)?(?:\(\d{3}\)|\d{3})[\s.-]?\d{3}[\s.-]?\d{4}\b/';
+
+        return (string) preg_replace($pattern, '[REDACTED:PHONE]', $text);
+    }
+}

--- a/app/config/filesystems.php
+++ b/app/config/filesystems.php
@@ -47,6 +47,13 @@ return [
             'report' => false,
         ],
 
+        'minio' => [
+            'driver' => 'local',
+            'root' => storage_path('app/minio'),
+            'throw' => false,
+            'report' => false,
+        ],
+
         's3' => [
             'driver' => 's3',
             'key' => env('AWS_ACCESS_KEY_ID'),

--- a/app/database/factories/ConsentFactory.php
+++ b/app/database/factories/ConsentFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Consent;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Consent>
+ */
+class ConsentFactory extends Factory
+{
+    protected $model = Consent::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'source' => $this->faker->domainName(),
+            'scope' => 'internal',
+            'status' => 'pending',
+            'notes' => null,
+        ];
+    }
+}

--- a/app/database/factories/DocumentFactory.php
+++ b/app/database/factories/DocumentFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Document;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Document>
+ */
+class DocumentFactory extends Factory
+{
+    protected $model = Document::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $content = $this->faker->paragraphs(2, true);
+
+        return [
+            'id' => (string) Str::uuid(),
+            'source' => $this->faker->domainName(),
+            'type' => 'text',
+            'status' => 'pending',
+            'sha256' => hash('sha256', $content),
+            'storage_disk' => 'minio',
+            'storage_path' => 'ingest/'.$this->faker->uuid.'.txt',
+            'original_filename' => null,
+            'mime_type' => 'text/plain',
+            'metadata' => ['faker' => true],
+            'tags' => ['sample'],
+            'retention_class' => 'standard',
+            'consent_scope' => 'internal',
+            'pii_scrubbed' => true,
+            'sanitized_content' => $content,
+        ];
+    }
+}

--- a/app/database/migrations/2025_09_22_170000_create_documents_table.php
+++ b/app/database/migrations/2025_09_22_170000_create_documents_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('documents', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->string('source');
+            $table->string('type');
+            $table->string('status')->default('pending');
+            $table->string('sha256');
+            $table->string('storage_disk')->default('minio');
+            $table->string('storage_path');
+            $table->string('original_filename')->nullable();
+            $table->string('mime_type')->nullable();
+            $table->json('metadata')->nullable();
+            $table->json('tags')->nullable();
+            $table->string('retention_class')->nullable();
+            $table->string('consent_scope');
+            $table->boolean('pii_scrubbed')->default(true);
+            $table->longText('sanitized_content')->nullable();
+            $table->text('rejection_reason')->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamp('rejected_at')->nullable();
+            $table->foreignId('submitted_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('reviewed_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['source', 'status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('documents');
+    }
+};

--- a/app/database/migrations/2025_09_22_170100_create_consents_table.php
+++ b/app/database/migrations/2025_09_22_170100_create_consents_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('consents', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignUuid('document_id')->nullable()->constrained('documents')->nullOnDelete();
+            $table->string('source');
+            $table->string('scope');
+            $table->string('status')->default('pending');
+            $table->text('notes')->nullable();
+            $table->timestamp('granted_at')->nullable();
+            $table->timestamp('revoked_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['source', 'document_id']);
+            $table->index(['source', 'status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('consents');
+    }
+};

--- a/app/resources/views/layouts/app.blade.php
+++ b/app/resources/views/layouts/app.blade.php
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ config('app.name', 'SELF') }}</title>
+    <link rel="preconnect" href="https://fonts.bunny.net">
+    <link rel="stylesheet" href="https://fonts.bunny.net/css?family=inter:400,500,600&display=swap">
+    <style>
+        :root {
+            font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            color: #1f2937;
+        }
+
+        body {
+            margin: 0;
+            background-color: #f1f5f9;
+        }
+
+        a {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        textarea,
+        input,
+        button {
+            font-family: inherit;
+        }
+    </style>
+</head>
+<body>
+    <nav style="background:#fff;box-shadow:0 1px 3px rgba(15,23,42,0.1);">
+        <div style="max-width:960px;margin:0 auto;padding:16px 24px;display:flex;justify-content:space-between;align-items:center;">
+            <div style="font-size:20px;font-weight:600;">SELF Review</div>
+            <div style="font-size:14px;color:#64748b;">{{ now()->toDayDateTimeString() }}</div>
+        </div>
+    </nav>
+    <main>
+        @yield('content')
+    </main>
+</body>
+</html>

--- a/app/resources/views/review/documents/index.blade.php
+++ b/app/resources/views/review/documents/index.blade.php
@@ -1,0 +1,75 @@
+@extends('layouts.app')
+
+@php
+    use Illuminate\Support\Str;
+@endphp
+
+@section('content')
+<div style="max-width:960px;margin:0 auto;padding:48px 24px;">
+    <h1 style="font-size:28px;font-weight:600;margin-bottom:24px;">Ingestion Review Queue</h1>
+
+    @if(session('status'))
+        <div style="background:#dcfce7;border:1px solid #86efac;color:#166534;padding:12px 16px;border-radius:6px;margin-bottom:16px;">
+            {{ session('status') }}
+        </div>
+    @endif
+
+    @if($documents->isEmpty())
+        <p style="color:#475569;">No documents are waiting for review.</p>
+    @else
+        <div style="overflow-x:auto;">
+            <table style="width:100%;background:#fff;border-radius:8px;box-shadow:0 1px 4px rgba(15,23,42,0.08);border-collapse:collapse;">
+                <thead>
+                    <tr style="background:#f8fafc;text-align:left;">
+                        <th style="padding:12px 16px;font-size:14px;text-transform:uppercase;letter-spacing:0.05em;color:#475569;">Source</th>
+                        <th style="padding:12px 16px;font-size:14px;text-transform:uppercase;letter-spacing:0.05em;color:#475569;">Type</th>
+                        <th style="padding:12px 16px;font-size:14px;text-transform:uppercase;letter-spacing:0.05em;color:#475569;">Submitted</th>
+                        <th style="padding:12px 16px;font-size:14px;text-transform:uppercase;letter-spacing:0.05em;color:#475569;">Preview</th>
+                        <th style="padding:12px 16px;font-size:14px;text-transform:uppercase;letter-spacing:0.05em;color:#475569;">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                @foreach($documents as $document)
+                    <tr style="border-top:1px solid #e2e8f0;vertical-align:top;">
+                        <td style="padding:16px;">
+                            <div style="font-weight:600;">{{ $document->source }}</div>
+                            <div style="font-size:13px;color:#64748b;">Retention: {{ $document->retention_class ?? 'standard' }}</div>
+                            <div style="font-size:13px;color:#64748b;">Consent: {{ $document->consent_scope }}</div>
+                        </td>
+                        <td style="padding:16px;font-size:14px;">{{ ucfirst($document->type) }}</td>
+                        <td style="padding:16px;font-size:14px;color:#475569;">{{ $document->created_at?->diffForHumans() }}</td>
+                        <td style="padding:16px;font-size:14px;color:#1e293b;">
+                            @if($document->sanitized_content)
+                                {{ Str::limit($document->sanitized_content, 180) }}
+                            @else
+                                <span style="font-style:italic;color:#94a3b8;">Binary asset</span>
+                            @endif
+                        </td>
+                        <td style="padding:16px;">
+                            <div style="display:flex;flex-direction:column;gap:12px;">
+                                <form method="POST" action="{{ route('review.documents.approve', $document) }}" style="display:flex;flex-direction:column;gap:8px;">
+                                    @csrf
+                                    <label for="notes-{{ $document->id }}" style="font-size:13px;color:#475569;">Notes (optional)</label>
+                                    <textarea id="notes-{{ $document->id }}" name="notes" rows="2" style="width:100%;padding:8px 10px;border:1px solid #cbd5f5;border-radius:4px;resize:vertical;">{{ old('notes') }}</textarea>
+                                    <button type="submit" style="background:#16a34a;color:#fff;padding:8px 12px;border:none;border-radius:4px;cursor:pointer;">Approve</button>
+                                </form>
+                                <form method="POST" action="{{ route('review.documents.reject', $document) }}" style="display:flex;flex-direction:column;gap:8px;">
+                                    @csrf
+                                    <label for="reason-{{ $document->id }}" style="font-size:13px;color:#475569;">Rejection reason</label>
+                                    <textarea id="reason-{{ $document->id }}" name="reason" rows="2" required style="width:100%;padding:8px 10px;border:1px solid #cbd5f5;border-radius:4px;resize:vertical;">{{ old('reason') }}</textarea>
+                                    <button type="submit" style="background:#dc2626;color:#fff;padding:8px 12px;border:none;border-radius:4px;cursor:pointer;">Reject</button>
+                                </form>
+                            </div>
+                        </td>
+                    </tr>
+                @endforeach
+                </tbody>
+            </table>
+        </div>
+
+        <div style="margin-top:16px;">
+            {{ $documents->links() }}
+        </div>
+    @endif
+</div>
+@endsection

--- a/app/routes/api.php
+++ b/app/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\IngestionController;
 use App\Support\Policy\PolicyVerifier;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -24,4 +25,11 @@ Route::get('/policy/verify', function (PolicyVerifier $verifier) {
         'valid' => true,
         'policy' => $result,
     ]);
+});
+
+Route::middleware('auth:sanctum')->prefix('v1')->group(function (): void {
+    Route::post('/ingest/text', [IngestionController::class, 'ingestText']);
+    Route::post('/ingest/file', [IngestionController::class, 'ingestFile']);
+    Route::delete('/ingest/document/{document}', [IngestionController::class, 'destroyDocument']);
+    Route::delete('/ingest/source/{source}', [IngestionController::class, 'destroyBySource']);
 });

--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -1,7 +1,14 @@
 <?php
 
+use App\Http\Controllers\ReviewDocumentController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
+});
+
+Route::middleware('auth')->prefix('review/documents')->name('review.documents.')->group(function (): void {
+    Route::get('/', [ReviewDocumentController::class, 'index'])->name('index');
+    Route::post('/{document}/approve', [ReviewDocumentController::class, 'approve'])->name('approve');
+    Route::post('/{document}/reject', [ReviewDocumentController::class, 'reject'])->name('reject');
 });

--- a/app/tests/Feature/IngestionEndpointsTest.php
+++ b/app/tests/Feature/IngestionEndpointsTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Consent;
+use App\Models\Document;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class IngestionEndpointsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_text_ingestion_scrubs_pii_and_stores_document(): void
+    {
+        Storage::fake('minio');
+
+        $user = User::factory()->create();
+        Sanctum::actingAs($user, ['*']);
+
+        $response = $this->postJson('/api/v1/ingest/text', [
+            'source' => 'journal',
+            'text' => 'Contact me at alice@example.com or 555-123-4567 tomorrow.',
+            'consent_scope' => 'personal',
+            'tags' => ['journal'],
+            'metadata' => ['submitted_via' => 'app'],
+            'retention_class' => 'standard',
+        ]);
+
+        $response->assertAccepted();
+        $response->assertJson(['pii_scrubbed' => true]);
+
+        $document = Document::firstOrFail();
+
+        $this->assertSame('journal', $document->source);
+        $this->assertTrue($document->pii_scrubbed);
+        $this->assertStringNotContainsString('alice@example.com', $document->sanitized_content);
+        $this->assertStringContainsString('[REDACTED:EMAIL]', $document->sanitized_content);
+        $this->assertStringContainsString('[REDACTED:PHONE]', $document->sanitized_content);
+        Storage::disk('minio')->assertExists($document->storage_path);
+
+        $this->assertDatabaseHas('consents', [
+            'document_id' => $document->id,
+            'source' => 'journal',
+            'status' => 'pending',
+        ]);
+    }
+
+    public function test_owner_can_bypass_pii_scrubbing(): void
+    {
+        Storage::fake('minio');
+
+        $ownerRole = Role::firstOrCreate([
+            'name' => 'owner',
+            'guard_name' => 'web',
+        ]);
+
+        $user = User::factory()->create();
+        $user->assignRole($ownerRole);
+        Sanctum::actingAs($user, ['*']);
+
+        $text = 'Here is my number: 555-000-1111.';
+
+        $response = $this->postJson('/api/v1/ingest/text', [
+            'source' => 'notes',
+            'text' => $text,
+            'consent_scope' => 'owner-only',
+            'bypass_pii_scrub' => true,
+        ]);
+
+        $response->assertAccepted();
+        $response->assertJson(['pii_scrubbed' => false]);
+
+        $document = Document::firstOrFail();
+        $this->assertSame($text, $document->sanitized_content);
+    }
+
+    public function test_non_owner_cannot_bypass_pii_scrubbing(): void
+    {
+        Storage::fake('minio');
+
+        $user = User::factory()->create();
+        Sanctum::actingAs($user, ['*']);
+
+        $response = $this->postJson('/api/v1/ingest/text', [
+            'source' => 'notes',
+            'text' => 'Sensitive 555-000-1111',
+            'consent_scope' => 'owner-only',
+            'bypass_pii_scrub' => true,
+        ]);
+
+        $response->assertForbidden();
+    }
+
+    public function test_file_ingestion_stores_binary_and_metadata(): void
+    {
+        Storage::fake('minio');
+
+        $user = User::factory()->create();
+        Sanctum::actingAs($user, ['*']);
+
+        $file = UploadedFile::fake()->create('transcript.pdf', 12, 'application/pdf');
+
+        $response = $this->post('/api/v1/ingest/file', [
+            'source' => 'archives',
+            'file' => $file,
+            'consent_scope' => 'personal',
+            'metadata' => ['submitted_via' => 'upload'],
+        ], ['Accept' => 'application/json']);
+
+        $response->assertAccepted();
+
+        $document = Document::firstOrFail();
+        $this->assertSame('file', $document->type);
+        $this->assertSame('application/pdf', $document->mime_type);
+        Storage::disk('minio')->assertExists($document->storage_path);
+    }
+
+    public function test_right_to_forget_by_document_soft_deletes_and_revokes_consent(): void
+    {
+        Storage::fake('minio');
+
+        $user = User::factory()->create();
+        Sanctum::actingAs($user, ['*']);
+
+        $document = Document::factory()->create([
+            'source' => 'journals',
+        ]);
+
+        Storage::disk('minio')->put($document->storage_path, 'test');
+
+        Consent::factory()->create([
+            'document_id' => $document->id,
+            'source' => 'journals',
+            'scope' => 'personal',
+        ]);
+
+        $response = $this->deleteJson("/api/v1/ingest/document/{$document->id}");
+        $response->assertOk();
+
+        $document->refresh();
+        $this->assertSame('deleted', $document->status);
+        $this->assertSoftDeleted('documents', ['id' => $document->id]);
+        $this->assertDatabaseHas('consents', [
+            'document_id' => $document->id,
+            'status' => 'revoked',
+        ]);
+    }
+
+    public function test_right_to_forget_by_source(): void
+    {
+        Storage::fake('minio');
+
+        $user = User::factory()->create();
+        Sanctum::actingAs($user, ['*']);
+
+        $documents = Document::factory()->count(2)->create([
+            'source' => 'source-xyz',
+        ]);
+
+        foreach ($documents as $document) {
+            Storage::disk('minio')->put($document->storage_path, 'test');
+            Consent::factory()->create([
+                'document_id' => $document->id,
+                'source' => 'source-xyz',
+                'scope' => 'personal',
+            ]);
+        }
+
+        $response = $this->deleteJson('/api/v1/ingest/source/source-xyz');
+        $response->assertOk();
+        $response->assertJson(['documents_removed' => 2]);
+
+        foreach ($documents as $document) {
+            $this->assertSoftDeleted('documents', ['id' => $document->id]);
+        }
+    }
+}

--- a/app/tests/Feature/ReviewQueueTest.php
+++ b/app/tests/Feature/ReviewQueueTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Consent;
+use App\Models\Document;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReviewQueueTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_review_queue_lists_pending_documents(): void
+    {
+        $user = User::factory()->create();
+        $document = Document::factory()->create([
+            'source' => 'notebook',
+            'sanitized_content' => 'sanitized text',
+        ]);
+
+        $this->actingAs($user);
+
+        $response = $this->get('/review/documents/');
+        $response->assertOk();
+        $response->assertSee('Ingestion Review Queue');
+        $response->assertSee($document->source);
+    }
+
+    public function test_approving_document_updates_status_and_consent(): void
+    {
+        $reviewer = User::factory()->create();
+        $document = Document::factory()->create();
+        $consent = Consent::factory()->create([
+            'document_id' => $document->id,
+            'source' => $document->source,
+            'scope' => $document->consent_scope,
+        ]);
+
+        $this->actingAs($reviewer);
+
+        $response = $this->post("/review/documents/{$document->id}/approve", [
+            'notes' => 'Looks good',
+        ]);
+
+        $response->assertRedirect('/review/documents');
+
+        $document->refresh();
+        $consent->refresh();
+
+        $this->assertSame('approved', $document->status);
+        $this->assertNotNull($document->approved_at);
+        $this->assertSame($reviewer->id, $document->reviewed_by);
+        $this->assertSame('approved', $consent->status);
+        $this->assertNotNull($consent->granted_at);
+        $this->assertSame('Looks good', $consent->notes);
+    }
+
+    public function test_rejecting_document_requires_reason_and_updates_records(): void
+    {
+        $reviewer = User::factory()->create();
+        $document = Document::factory()->create();
+        $consent = Consent::factory()->create([
+            'document_id' => $document->id,
+            'source' => $document->source,
+            'scope' => $document->consent_scope,
+        ]);
+
+        $this->actingAs($reviewer);
+
+        $response = $this->post("/review/documents/{$document->id}/reject", [
+            'reason' => 'PII detected',
+        ]);
+
+        $response->assertRedirect('/review/documents');
+
+        $document->refresh();
+        $consent->refresh();
+
+        $this->assertSame('rejected', $document->status);
+        $this->assertNotNull($document->rejected_at);
+        $this->assertSame('PII detected', $document->rejection_reason);
+        $this->assertSame('rejected', $consent->status);
+        $this->assertNull($consent->granted_at);
+        $this->assertSame('PII detected', $consent->notes);
+    }
+
+    public function test_reviewing_non_pending_document_returns_conflict(): void
+    {
+        $reviewer = User::factory()->create();
+        $document = Document::factory()->create([
+            'status' => 'approved',
+        ]);
+
+        $this->actingAs($reviewer);
+
+        $response = $this->post("/review/documents/{$document->id}/approve");
+        $response->assertStatus(409);
+    }
+}


### PR DESCRIPTION
## Summary
- add document and consent persistence with ingestion endpoints for text and file sources, including PII scrubbing and storage in the MinIO disk
- introduce pending review queue UI with approve/reject actions that update consent records and provide reviewer feedback
- cover ingestion, deletion, and review flows with feature tests and register supporting factories, migrations, and storage configuration

## Testing
- `php artisan test`

## Migration
- `php artisan migrate`

## Rollback
- `php artisan migrate:rollback --step=2`


------
https://chatgpt.com/codex/tasks/task_e_68d1b81b993c8322ae75a78bda3f3456