### PR TITLE
Implement chat service with guardrails and budgets

### DIFF
--- a/app/app/Http/Controllers/Api/ChatController.php
+++ b/app/app/Http/Controllers/Api/ChatController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Support\Chat\ChatBudgetExceededException;
+use App\Support\Chat\ChatService;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Symfony\Component\HttpFoundation\Response;
+
+class ChatController extends Controller
+{
+    public function __construct(private readonly ChatService $chatService)
+    {
+    }
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $modes = array_keys(config('chat.modes', []));
+        $explanationLevels = config('chat.explanation.levels', ['terse', 'detailed']);
+
+        $validated = $request->validate([
+            'mode' => ['required', 'string', 'in:'.implode(',', $modes)],
+            'prompt' => ['required', 'string', 'min:3'],
+            'controls' => ['sometimes', 'array'],
+            'controls.explanation' => ['sometimes', 'string', 'in:'.implode(',', $explanationLevels)],
+        ]);
+
+        try {
+            $result = $this->chatService->respond(
+                $request->user(),
+                $validated['mode'],
+                $validated['prompt'],
+                Arr::get($validated, 'controls', [])
+            );
+        } catch (ChatBudgetExceededException $exception) {
+            $type = $exception->budgetType;
+            $snapshot = $exception->snapshot;
+            $budget = $snapshot[$type] ?? [];
+            $retryAfter = null;
+            if (isset($budget['reset_at'])) {
+                $resetAt = CarbonImmutable::parse($budget['reset_at']);
+                $retryAfter = now()->diffInSeconds($resetAt, false);
+                if ($retryAfter < 0) {
+                    $retryAfter = 0;
+                }
+            }
+
+            $response = response()->json([
+                'error' => 'budget_exceeded',
+                'budget_type' => $type,
+                'message' => $exception->getMessage(),
+                'budget' => $snapshot,
+            ], Response::HTTP_TOO_MANY_REQUESTS);
+
+            if ($retryAfter !== null) {
+                $response->headers->set('Retry-After', (string) $retryAfter);
+            }
+
+            return $response;
+        }
+
+        return response()->json($result, Response::HTTP_OK);
+    }
+}

--- a/app/app/Support/Chat/ChatBudgetExceededException.php
+++ b/app/app/Support/Chat/ChatBudgetExceededException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Support\Chat;
+
+use RuntimeException;
+
+class ChatBudgetExceededException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $budgetType,
+        public readonly array $snapshot
+    ) {
+        parent::__construct("Chat {$budgetType} budget exceeded.");
+    }
+}

--- a/app/app/Support/Chat/ChatBudgetManager.php
+++ b/app/app/Support/Chat/ChatBudgetManager.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Support\Chat;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+
+class ChatBudgetManager
+{
+    public function __construct(private readonly CacheRepository $cache)
+    {
+    }
+
+    /**
+     * Consume the requested budget and return the latest snapshot.
+     *
+     * @param  int<0, max>  $tokens
+     * @param  int<0, max>  $seconds
+     * @return array{
+     *     tokens: array{limit: int, used: int, remaining: int, reset_at: string},
+     *     seconds: array{limit: int, used: int, remaining: int, reset_at: string}
+     * }
+     */
+    public function consume(?int $userId, int $tokens, int $seconds): array
+    {
+        $snapshot = $this->snapshot($userId);
+        $limits = config('chat.budget');
+
+        if (($limits['tokens']['daily_limit'] ?? 0) > 0) {
+            $limit = (int) $limits['tokens']['daily_limit'];
+            $used = $snapshot['tokens']['used'];
+
+            if ($used + $tokens > $limit) {
+                $snapshot['tokens']['requested'] = $tokens;
+                throw new ChatBudgetExceededException('tokens', $snapshot);
+            }
+
+            $this->cache->put(
+                $this->tokenCacheKey($userId),
+                $used + $tokens,
+                CarbonImmutable::now()->endOfDay()
+            );
+        }
+
+        if (($limits['seconds']['per_minute_limit'] ?? 0) > 0) {
+            $limit = (int) $limits['seconds']['per_minute_limit'];
+            $used = $snapshot['seconds']['used'];
+
+            if ($used + $seconds > $limit) {
+                $snapshot['seconds']['requested'] = $seconds;
+                throw new ChatBudgetExceededException('seconds', $snapshot);
+            }
+
+            $this->cache->put(
+                $this->secondsCacheKey($userId),
+                $used + $seconds,
+                CarbonImmutable::now()->startOfMinute()->addMinute()
+            );
+        }
+
+        return $this->snapshot($userId);
+    }
+
+    /**
+     * Get the current budget snapshot without consuming.
+     *
+     * @return array{
+     *     tokens: array{limit: int, used: int, remaining: int, reset_at: string},
+     *     seconds: array{limit: int, used: int, remaining: int, reset_at: string}
+     * }
+     */
+    public function snapshot(?int $userId): array
+    {
+        $limits = config('chat.budget');
+        $tokenLimit = (int) ($limits['tokens']['daily_limit'] ?? 0);
+        $secondsLimit = (int) ($limits['seconds']['per_minute_limit'] ?? 0);
+
+        $usedTokens = (int) $this->cache->get($this->tokenCacheKey($userId), 0);
+        $usedSeconds = (int) $this->cache->get($this->secondsCacheKey($userId), 0);
+
+        $tokenReset = CarbonImmutable::now()->endOfDay();
+        $secondsReset = CarbonImmutable::now()->startOfMinute()->addMinute();
+
+        return [
+            'tokens' => [
+                'limit' => $tokenLimit,
+                'used' => min($usedTokens, $tokenLimit > 0 ? $tokenLimit : $usedTokens),
+                'remaining' => max(0, $tokenLimit - $usedTokens),
+                'reset_at' => $tokenReset->toIso8601String(),
+            ],
+            'seconds' => [
+                'limit' => $secondsLimit,
+                'used' => min($usedSeconds, $secondsLimit > 0 ? $secondsLimit : $usedSeconds),
+                'remaining' => max(0, $secondsLimit - $usedSeconds),
+                'reset_at' => $secondsReset->toIso8601String(),
+            ],
+        ];
+    }
+
+    private function tokenCacheKey(?int $userId): string
+    {
+        $userKey = $this->userKey($userId);
+
+        return "chat:budget:tokens:{$userKey}:".CarbonImmutable::now()->format('Y-m-d');
+    }
+
+    private function secondsCacheKey(?int $userId): string
+    {
+        $userKey = $this->userKey($userId);
+
+        return "chat:budget:seconds:{$userKey}:".CarbonImmutable::now()->format('Y-m-d-H-i');
+    }
+
+    private function userKey(?int $userId): string
+    {
+        return $userId ? 'user-'.$userId : 'anonymous';
+    }
+}

--- a/app/app/Support/Chat/ChatService.php
+++ b/app/app/Support/Chat/ChatService.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace App\Support\Chat;
+
+use App\Models\AuditLog;
+use App\Models\User;
+use App\Support\Memory\MemorySearchService;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class ChatService
+{
+    public function __construct(
+        private readonly MemorySearchService $memorySearch,
+        private readonly ChatBudgetManager $budgetManager,
+        private readonly TopicBlocker $topicBlocker
+    ) {
+    }
+
+    /**
+     * @param  array<string, mixed>  $controls
+     * @return array<string, mixed>
+     */
+    public function respond(?User $user, string $mode, string $prompt, array $controls = []): array
+    {
+        $explanationLevel = $this->resolveExplanationLevel($controls['explanation'] ?? null);
+        $blocked = $this->topicBlocker->detect($prompt);
+
+        if ($blocked) {
+            $snapshot = $this->budgetManager->snapshot($user?->id);
+            $this->logRefusal($user, $prompt, $blocked);
+
+            return [
+                'status' => 'refused',
+                'mode' => $mode,
+                'reply' => $this->formatRefusalMessage($blocked),
+                'citations' => [],
+                'why_card' => $this->refusalWhyCard($mode, $blocked),
+                'budget' => $snapshot,
+            ];
+        }
+
+        $tokenEstimate = $this->estimateTokens($prompt);
+        $secondEstimate = $this->estimateSeconds($tokenEstimate);
+        $budget = $this->budgetManager->consume($user?->id, $tokenEstimate, $secondEstimate);
+
+        $memoryLimit = (int) config('chat.search.memory_limit', 5);
+        $hits = $this->memorySearch->search($prompt, ['limit' => $memoryLimit]);
+        $citations = $this->buildCitations($hits);
+        $reply = $this->composeReply($mode, $prompt, $hits, $citations, $explanationLevel);
+        $whyCard = $this->buildWhyCard($mode, $explanationLevel, $hits, $citations, $tokenEstimate, $secondEstimate);
+
+        return [
+            'status' => 'ok',
+            'mode' => $mode,
+            'reply' => $reply,
+            'citations' => $citations,
+            'why_card' => $whyCard,
+            'budget' => $budget,
+        ];
+    }
+
+    private function resolveExplanationLevel(?string $value): string
+    {
+        $levels = config('chat.explanation.levels', ['terse', 'detailed']);
+        $default = config('chat.explanation.default', 'detailed');
+
+        if (! is_string($value)) {
+            return $default;
+        }
+
+        $value = Str::lower($value);
+
+        return in_array($value, $levels, true) ? $value : $default;
+    }
+
+    /**
+     * @param  array{topic: string, message: string, safe_alternative: string}  $block
+     */
+    private function formatRefusalMessage(array $block): string
+    {
+        return trim($block['message'].' '.$block['safe_alternative']);
+    }
+
+    /**
+     * @param  array{topic: string, message: string, safe_alternative: string}  $block
+     * @return array<string, mixed>
+     */
+    private function refusalWhyCard(string $mode, array $block): array
+    {
+        return [
+            'mode' => $mode,
+            'detail_level' => 'terse',
+            'summary' => sprintf('Refused: %s guidance is blocked for safety.', ucfirst($block['topic'])),
+            'safety' => [
+                'blocked_topic' => $block['topic'],
+                'message' => $block['message'],
+            ],
+            'next_step' => $block['safe_alternative'],
+            'citations_considered' => 0,
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildCitations(Collection $hits): array
+    {
+        return $hits
+            ->values()
+            ->map(function (array $hit, int $index): array {
+                return [
+                    'id' => 'c'.($index + 1),
+                    'document_id' => $hit['document_id'] ?? null,
+                    'source' => $hit['source_id'] ?? null,
+                    'excerpt' => Str::limit((string) ($hit['chunk'] ?? ''), 220),
+                    'score' => isset($hit['score']) ? round((float) $hit['score'], 4) : null,
+                    'timestamp' => $hit['ts'] ?? null,
+                ];
+            })
+            ->all();
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $citations
+     */
+    private function composeReply(string $mode, string $prompt, Collection $hits, array $citations, string $explanationLevel): string
+    {
+        $modeDefinition = Arr::get(config('chat.modes'), $mode, []);
+        $lead = Arr::get($modeDefinition, 'lead', Str::title($mode));
+        $tone = Arr::get($modeDefinition, 'tone', 'supportive');
+
+        $lines = [];
+        $promptSummary = Str::limit($prompt, $explanationLevel === 'terse' ? 120 : 180);
+        $lines[] = 'You asked: "'.$promptSummary.'"';
+        $insights = $hits->take($explanationLevel === 'terse' ? 1 : 3)->values();
+
+        foreach ($insights as $index => $hit) {
+            $citationId = Arr::get($citations, $index.'.id');
+            $excerpt = Str::limit((string) ($hit['chunk'] ?? ''), $explanationLevel === 'terse' ? 140 : 220);
+            $lines[] = sprintf('Insight %d: %s%s', $index + 1, $excerpt, $citationId ? " [{$citationId}]" : '');
+        }
+
+        if ($insights->isEmpty()) {
+            $lines[] = 'I do not have indexed memories on this yet. Let us capture more context before I advise further.';
+        }
+
+        $closing = match ($mode) {
+            'coach' => 'Let us pick one next step you can take confidently. I can help you break it down.',
+            'analyst' => 'Consider the evidence above and decide what data you need next. I can help outline experiments or metrics.',
+            'listener' => 'I am here to keep reflecting with you. Share more if something still feels unresolved.',
+            default => 'Let me know how you would like to continue and I will stay aligned with your boundaries.',
+        };
+
+        if ($explanationLevel === 'terse') {
+            $closing = Str::before($closing, '.').' when you are ready.';
+        }
+
+        return sprintf(
+            "%s (%s)\n%s\n\n%s",
+            $lead,
+            $tone,
+            implode(PHP_EOL, array_map(fn ($line) => '- '.$line, $lines)),
+            $closing
+        );
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $citations
+     * @return array<string, mixed>
+     */
+    private function buildWhyCard(string $mode, string $explanationLevel, Collection $hits, array $citations, int $tokens, int $seconds): array
+    {
+        $summary = $explanationLevel === 'terse'
+            ? 'Quick take grounded in the top memory snippet I found relevant.'
+            : 'Combined your prompt with consented memories to craft a grounded response with context for next steps.';
+
+        return [
+            'mode' => $mode,
+            'detail_level' => $explanationLevel,
+            'summary' => $summary,
+            'memory' => [
+                'considered' => $hits->count(),
+                'used_citations' => array_column($citations, 'id'),
+                'top_scores' => $hits->take(3)->map(fn ($hit) => isset($hit['score']) ? round((float) $hit['score'], 4) : null)->filter()->values()->all(),
+            ],
+            'safety' => [
+                'topic_blocks_checked' => array_keys(config('chat.topic_blocks', [])),
+                'refused' => false,
+            ],
+            'budget' => [
+                'prompt_tokens_estimate' => $tokens,
+                'processing_seconds_estimate' => $seconds,
+            ],
+        ];
+    }
+
+    private function estimateTokens(string $prompt): int
+    {
+        $words = str_word_count($prompt);
+        $tokens = (int) ceil($words * 1.2);
+
+        return max(1, $tokens);
+    }
+
+    private function estimateSeconds(int $tokens): int
+    {
+        return max(1, (int) ceil($tokens / 120));
+    }
+
+    /**
+     * @param  array{topic: string, message: string, safe_alternative: string}  $block
+     */
+    private function logRefusal(?User $user, string $prompt, array $block): void
+    {
+        $timestamp = now();
+        $actor = $user?->email ?? 'system';
+        $context = [
+            'topic' => $block['topic'],
+            'message' => $block['message'],
+            'prompt_preview' => Str::limit($prompt, 180),
+        ];
+
+        DB::transaction(function () use ($timestamp, $actor, $context): void {
+            $query = AuditLog::query()->latest('id');
+            if (DB::connection()->getDriverName() !== 'sqlite') {
+                $query->lockForUpdate();
+            }
+
+            $previousHash = $query->value('hash');
+            $payload = [
+                'actor' => $actor,
+                'action' => 'chat.refusal',
+                'target' => 'chat',
+                'context' => $context,
+                'previous_hash' => $previousHash,
+                'created_at' => $timestamp->toIso8601String(),
+            ];
+
+            $hash = hash('sha256', json_encode($payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
+
+            AuditLog::query()->create([
+                'actor' => $actor,
+                'action' => 'chat.refusal',
+                'target' => 'chat',
+                'context' => $context,
+                'hash' => $hash,
+                'previous_hash' => $previousHash,
+                'created_at' => $timestamp,
+            ]);
+        });
+    }
+}

--- a/app/app/Support/Chat/TopicBlocker.php
+++ b/app/app/Support/Chat/TopicBlocker.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Support\Chat;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+class TopicBlocker
+{
+    /**
+     * Detect whether the prompt matches a blocked topic.
+     *
+     * @return array{topic: string, message: string, safe_alternative: string}|null
+     */
+    public function detect(string $prompt): ?array
+    {
+        $prompt = Str::lower($prompt);
+        $blocks = config('chat.topic_blocks', []);
+
+        foreach ($blocks as $topic => $definition) {
+            $keywords = Arr::get($definition, 'keywords', []);
+            foreach ($keywords as $keyword) {
+                $keyword = Str::lower($keyword);
+                if ($keyword === '') {
+                    continue;
+                }
+
+                if (Str::contains($prompt, $keyword)) {
+                    return [
+                        'topic' => (string) $topic,
+                        'message' => (string) Arr::get($definition, 'message', ''),
+                        'safe_alternative' => (string) Arr::get($definition, 'safe_alternative', ''),
+                    ];
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/config/chat.php
+++ b/app/config/chat.php
@@ -1,0 +1,58 @@
+<?php
+
+return [
+    'modes' => [
+        'coach' => [
+            'label' => 'Coach',
+            'lead' => 'Coach perspective',
+            'tone' => 'encouraging and action-focused',
+        ],
+        'analyst' => [
+            'label' => 'Analyst',
+            'lead' => 'Analyst brief',
+            'tone' => 'structured and neutral',
+        ],
+        'listener' => [
+            'label' => 'Listener',
+            'lead' => 'Listener reflection',
+            'tone' => 'empathetic and validating',
+        ],
+    ],
+
+    'explanation' => [
+        'default' => 'detailed',
+        'levels' => ['terse', 'detailed'],
+    ],
+
+    'topic_blocks' => [
+        'medical' => [
+            'keywords' => [
+                'diagnos', 'prescrib', 'medical advice', 'treatment plan', 'symptom',
+                'medication', 'dose', 'therapy recommendation', 'disease',
+            ],
+            'message' => 'I am not a medical professional and cannot help with clinical guidance.',
+            'safe_alternative' => 'Please consult a licensed medical professional who can review your situation directly. I can help you prepare questions for that conversation or explore general wellness habits.',
+        ],
+        'financial' => [
+            'keywords' => [
+                'stock tip', 'investment advice', 'financial advice', 'buy crypto', 'which stock',
+                'retirement account', 'portfolio allocation', 'insider trading',
+            ],
+            'message' => 'I am not permitted to provide personalised financial guidance.',
+            'safe_alternative' => 'A fiduciary financial advisor can give you tailored recommendations. I am happy to help you list out questions to ask them or clarify general budgeting frameworks.',
+        ],
+    ],
+
+    'budget' => [
+        'tokens' => [
+            'daily_limit' => (int) env('CHAT_TOKEN_DAILY_LIMIT', 6000),
+        ],
+        'seconds' => [
+            'per_minute_limit' => (int) env('CHAT_SECONDS_PER_MINUTE_LIMIT', 45),
+        ],
+    ],
+
+    'search' => [
+        'memory_limit' => 5,
+    ],
+];

--- a/app/routes/api.php
+++ b/app/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\ChatController;
 use App\Http\Controllers\Api\IngestionController;
 use App\Http\Controllers\Api\MemorySearchController;
 use App\Support\Policy\PolicyVerifier;
@@ -34,4 +35,5 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function (): void {
     Route::delete('/ingest/document/{document}', [IngestionController::class, 'destroyDocument']);
     Route::delete('/ingest/source/{source}', [IngestionController::class, 'destroyBySource']);
     Route::get('/memory/search', MemorySearchController::class);
+    Route::post('/chat', ChatController::class);
 });

--- a/app/tests/Feature/Chat/ChatEndpointTest.php
+++ b/app/tests/Feature/Chat/ChatEndpointTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Feature\Chat;
+
+use App\Models\AuditLog;
+use App\Models\Document;
+use App\Models\Memory;
+use App\Models\User;
+use App\Support\Memory\Drivers\ArrayEmbeddingStore;
+use App\Support\Memory\EmbeddingStoreManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ChatEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['vector.driver' => 'array']);
+        ArrayEmbeddingStore::reset();
+    }
+
+    public function test_chat_returns_coach_response_with_citations_and_why_card(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user, ['*']);
+
+        $document = Document::factory()->create([
+            'status' => 'approved',
+            'source' => 'journal',
+            'sanitized_content' => 'Hydration and short recovery breaks helped last week.',
+            'consent_scope' => 'personal-health',
+        ]);
+
+        $this->createMemory($document, 'Remember to hydrate before workouts and schedule lighter recovery days.');
+
+        $response = $this->postJson('/api/v1/chat', [
+            'mode' => 'coach',
+            'prompt' => 'How can I keep my energy up during training this month?',
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('mode', 'coach');
+        $response->assertJsonStructure([
+            'status', 'reply', 'citations', 'why_card', 'budget',
+        ]);
+
+        $payload = $response->json();
+        $this->assertSame('ok', $payload['status']);
+        $this->assertStringContainsString('Coach perspective', $payload['reply']);
+        $this->assertNotEmpty($payload['citations']);
+        $this->assertSame($document->id, $payload['citations'][0]['document_id']);
+        $this->assertSame('detailed', $payload['why_card']['detail_level']);
+        $this->assertGreaterThan(0, $payload['budget']['tokens']['limit']);
+        $this->assertArrayHasKey('remaining', $payload['budget']['tokens']);
+    }
+
+    public function test_chat_allows_explanation_dial(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user, ['*']);
+
+        $document = Document::factory()->create([
+            'status' => 'approved',
+            'source' => 'projects',
+            'sanitized_content' => 'Weekly review template stored in archives.',
+            'consent_scope' => 'work',
+        ]);
+
+        $this->createMemory($document, 'Use a quick retrospective: wins, blockers, one improvement.');
+
+        $response = $this->postJson('/api/v1/chat', [
+            'mode' => 'analyst',
+            'prompt' => 'Give me a fast format for my sprint retro.',
+            'controls' => [
+                'explanation' => 'terse',
+            ],
+        ]);
+
+        $response->assertOk();
+        $payload = $response->json();
+
+        $this->assertSame('ok', $payload['status']);
+        $this->assertSame('terse', $payload['why_card']['detail_level']);
+        $this->assertStringContainsString('Analyst brief', $payload['reply']);
+        $this->assertStringContainsString('when you are ready', $payload['reply']);
+    }
+
+    public function test_chat_blocks_high_risk_topics_and_logs_refusal(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user, ['*']);
+
+        $response = $this->postJson('/api/v1/chat', [
+            'mode' => 'listener',
+            'prompt' => 'I need a medical diagnosis for chest pain right now.',
+        ]);
+
+        $response->assertOk();
+        $payload = $response->json();
+
+        $this->assertSame('refused', $payload['status']);
+        $this->assertSame('medical', $payload['why_card']['safety']['blocked_topic']);
+        $this->assertEmpty($payload['citations']);
+        $this->assertStringContainsString('consult a licensed medical professional', $payload['reply']);
+
+        $this->assertTrue(
+            AuditLog::query()->where('action', 'chat.refusal')->exists(),
+            'Refusal should be recorded in the audit log.'
+        );
+    }
+
+    public function test_chat_enforces_budget_limits(): void
+    {
+        config([
+            'chat.budget.tokens.daily_limit' => 4,
+            'chat.budget.seconds.per_minute_limit' => 120,
+        ]);
+
+        $user = User::factory()->create();
+        Sanctum::actingAs($user, ['*']);
+
+        $response = $this->postJson('/api/v1/chat', [
+            'mode' => 'coach',
+            'prompt' => 'This prompt should burn through the token budget immediately for testing.',
+        ]);
+
+        $response->assertStatus(429);
+        $response->assertJsonPath('error', 'budget_exceeded');
+        $response->assertJsonPath('budget_type', 'tokens');
+        $payload = $response->json();
+        $this->assertSame(4, $payload['budget']['tokens']['limit']);
+        $this->assertSame(4, $payload['budget']['tokens']['remaining']);
+    }
+
+    private function createMemory(Document $document, string $text): void
+    {
+        $memory = Memory::create([
+            'document_id' => $document->id,
+            'vector_id' => null,
+            'chunk_index' => 0,
+            'chunk_offset' => 0,
+            'chunk_length' => mb_strlen($text, 'UTF-8'),
+            'chunk_text' => $text,
+            'source' => $document->source,
+            'embedding_model' => 'hashed-self-1',
+            'embedding_hash' => hash('sha256', $text),
+            'metadata' => [
+                'tags' => $document->tags ?? [],
+                'consent_scope' => $document->consent_scope,
+            ],
+        ]);
+
+        $store = app(EmbeddingStoreManager::class)->driver('array');
+        $memory->vector_id = $store->addMemory($memory, $text);
+        $memory->save();
+    }
+}

--- a/app/tests/TestCase.php
+++ b/app/tests/TestCase.php
@@ -13,6 +13,12 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
 
+        config([
+            'cache.default' => 'array',
+            'queue.default' => 'sync',
+            'broadcasting.default' => 'log',
+        ]);
+
         Cache::clear();
     }
 }


### PR DESCRIPTION
## Summary
- add chat configuration for modes, explanation levels, topic blocks, and usage budgets
- implement the chat service, controller, and support utilities to deliver modeful replies with citations, topic blocking, and budget tracking
- cover the new chat endpoint with feature tests and align the base test harness with array-backed infrastructure

## Testing
- composer test

## MIGRATION
- No database migrations are required.

## ROLLBACK
- Revert this change and clear any `chat:budget:*` cache keys to remove budget snapshots.

------
https://chatgpt.com/codex/tasks/task_e_68d1c9a2247c8322a2507f4a4c299f58