### PR TITLE
Add owner voice enrollment and kill switch support

### DIFF
--- a/app/app/Http/Controllers/Api/VoiceController.php
+++ b/app/app/Http/Controllers/Api/VoiceController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Support\Audio\VoiceRegistry;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class VoiceController extends Controller
+{
+    public function __construct(private readonly VoiceRegistry $voiceRegistry)
+    {
+    }
+
+    public function enrol(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        if (! $user || ! $user->hasRole('owner')) {
+            abort(Response::HTTP_FORBIDDEN, 'Only the owner may enrol a voice.');
+        }
+
+        $validated = $request->validate([
+            'dataset' => ['required', 'file', 'max:102400', 'mimetypes:application/zip,audio/wav,audio/wave,audio/x-wav,audio/flac,audio/x-flac,audio/ogg,audio/opus'],
+            'script_version' => ['required', 'string', 'max:100'],
+            'consent_scope' => ['required', 'string', 'max:255'],
+            'consent_notes' => ['nullable', 'string', 'max:1000'],
+            'script_text' => ['nullable', 'string', 'max:5000'],
+            'sample_count' => ['nullable', 'integer', 'min:1', 'max:400'],
+            'script_acknowledged' => ['required', 'accepted'],
+        ]);
+
+        $voice = $this->voiceRegistry->enrolOwnerVoice(
+            $user,
+            $validated['dataset'],
+            $validated['script_version'],
+            $validated['consent_scope'],
+            $validated['script_text'] ?? null,
+            $validated['consent_notes'] ?? null,
+            $validated['sample_count'] ?? null
+        );
+
+        return response()->json([
+            'voice_id' => $voice->voice_id,
+            'status' => $voice->status,
+            'dataset_sha256' => $voice->dataset_sha256,
+            'enrolled_at' => $voice->enrolled_at?->toIso8601String(),
+            'consent_scope' => $voice->consent_scope,
+        ], Response::HTTP_CREATED);
+    }
+
+    public function killSwitch(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        if (! $user || ! $user->hasRole('owner')) {
+            abort(Response::HTTP_FORBIDDEN, 'Only the owner may disable the voice.');
+        }
+
+        $validated = $request->validate([
+            'reason' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        $voice = $this->voiceRegistry->disableOwnerVoice($user, $validated['reason'] ?? 'owner_kill_switch');
+
+        if (! $voice) {
+            return response()->json([
+                'status' => 'not_enrolled',
+            ]);
+        }
+
+        return response()->json([
+            'voice_id' => $voice->voice_id,
+            'status' => $voice->status,
+            'disabled_at' => $voice->disabled_at?->toIso8601String(),
+            'reason' => $voice->disabled_reason,
+        ]);
+    }
+}

--- a/app/app/Models/Voice.php
+++ b/app/app/Models/Voice.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Str;
+
+class Voice extends Model
+{
+    use HasFactory;
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     */
+    public $incrementing = false;
+
+    /**
+     * The data type of the primary key ID.
+     */
+    protected $keyType = 'string';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'id',
+        'voice_id',
+        'status',
+        'storage_disk',
+        'dataset_path',
+        'dataset_sha256',
+        'sample_count',
+        'script_version',
+        'consent_scope',
+        'metadata',
+        'enrolled_at',
+        'enrolled_by',
+        'disabled_at',
+        'disabled_reason',
+        'disabled_by',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'metadata' => 'array',
+            'enrolled_at' => 'datetime',
+            'disabled_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * Boot the model.
+     */
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::creating(function (self $model): void {
+            if (! $model->getKey()) {
+                $model->setAttribute($model->getKeyName(), (string) Str::uuid());
+            }
+        });
+    }
+
+    /**
+     * User who enrolled the voice.
+     */
+    public function enroller(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'enrolled_by');
+    }
+
+    /**
+     * User who disabled the voice.
+     */
+    public function disabler(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'disabled_by');
+    }
+}

--- a/app/app/Support/Audio/ImpersonationGuard.php
+++ b/app/app/Support/Audio/ImpersonationGuard.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Support\Audio;
+
+use Illuminate\Support\Str;
+
+class ImpersonationGuard
+{
+    /**
+     * Detect if text attempts to impersonate a third-party voice.
+     *
+     * @return array{keyword: string, message: string, alternative: string}|null
+     */
+    public function detect(string $text): ?array
+    {
+        $haystack = Str::lower($text);
+        $keywords = [
+            'impersonate',
+            'imitate',
+            'mimic',
+            'sound like',
+            'speak like',
+            'voice of',
+            'as if you were',
+            'pretend to be',
+        ];
+
+        foreach ($keywords as $keyword) {
+            if (Str::contains($haystack, $keyword)) {
+                return [
+                    'keyword' => $keyword,
+                    'message' => 'I cannot impersonate named third parties.',
+                    'alternative' => 'I can use the neutral SELF voice or help you license an approved synthetic style.',
+                ];
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/app/Support/Audio/TtsService.php
+++ b/app/app/Support/Audio/TtsService.php
@@ -3,19 +3,43 @@
 namespace App\Support\Audio;
 
 use App\Jobs\SynthesizeSpeech;
+use App\Models\AuditLog;
 use App\Models\TtsRequest;
 use App\Models\User;
 use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 class TtsService
 {
+    public function __construct(
+        private readonly VoiceRegistry $voiceRegistry,
+        private readonly ImpersonationGuard $impersonationGuard
+    ) {
+    }
+
     /**
      * Generate speech for the provided text and return the request record.
+     *
+     * @throws VoiceImpersonationRejectedException
+     * @throws VoiceUnavailableException
      */
     public function synthesize(string $text, string $voiceId, ?User $user = null): TtsRequest
     {
+        $impersonation = $this->impersonationGuard->detect($text);
+        if ($impersonation !== null) {
+            $this->logImpersonationRefusal($user, $text, $voiceId, $impersonation);
+
+            throw new VoiceImpersonationRejectedException(
+                $impersonation['keyword'],
+                $impersonation['message'],
+                $impersonation['alternative']
+            );
+        }
+
+        $this->voiceRegistry->ensureVoiceAvailable($voiceId);
+
         $disk = config('audio.storage_disk', 'minio');
         $now = CarbonImmutable::now();
         $runId = (string) Str::uuid();
@@ -57,5 +81,51 @@ class TtsService
         }
 
         return $request->fresh() ?? $request;
+    }
+
+    /**
+     * @param  array{keyword: string, message: string, alternative: string}  $details
+     */
+    private function logImpersonationRefusal(?User $user, string $text, string $voiceId, array $details): void
+    {
+        $timestamp = now();
+        $actor = $user?->email ?? 'system';
+        $context = [
+            'voice_id' => $voiceId,
+            'keyword' => $details['keyword'],
+            'message' => $details['message'],
+            'prompt_preview' => Str::limit($text, 180),
+        ];
+
+        DB::transaction(function () use ($actor, $context, $timestamp): void {
+            $query = AuditLog::query()->latest('id');
+
+            if (DB::connection()->getDriverName() !== 'sqlite') {
+                $query->lockForUpdate();
+            }
+
+            $previousHash = $query->value('hash');
+
+            $payload = [
+                'actor' => $actor,
+                'action' => 'voice.impersonation_refused',
+                'target' => 'voice',
+                'context' => $context,
+                'previous_hash' => $previousHash,
+                'created_at' => $timestamp->toIso8601String(),
+            ];
+
+            $hash = hash('sha256', json_encode($payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
+
+            AuditLog::query()->create([
+                'actor' => $actor,
+                'action' => 'voice.impersonation_refused',
+                'target' => 'voice',
+                'context' => $context,
+                'hash' => $hash,
+                'previous_hash' => $previousHash,
+                'created_at' => $timestamp,
+            ]);
+        });
     }
 }

--- a/app/app/Support/Audio/VoiceImpersonationRejectedException.php
+++ b/app/app/Support/Audio/VoiceImpersonationRejectedException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Support\Audio;
+
+use RuntimeException;
+
+class VoiceImpersonationRejectedException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $keyword,
+        public readonly string $messageText,
+        public readonly string $alternative
+    ) {
+        parent::__construct($messageText);
+    }
+}

--- a/app/app/Support/Audio/VoiceRegistry.php
+++ b/app/app/Support/Audio/VoiceRegistry.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace App\Support\Audio;
+
+use App\Models\AuditLog;
+use App\Models\Consent;
+use App\Models\User;
+use App\Models\Voice;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class VoiceRegistry
+{
+    /**
+     * Register or refresh the owner voice dataset.
+     */
+    public function enrolOwnerVoice(
+        User $user,
+        UploadedFile $dataset,
+        string $scriptVersion,
+        string $consentScope,
+        ?string $scriptText = null,
+        ?string $consentNotes = null,
+        ?int $sampleCount = null
+    ): Voice {
+        $disk = config('audio.storage_disk', 'minio');
+        $now = CarbonImmutable::now();
+        $runId = (string) Str::uuid();
+        $directory = sprintf(
+            'voice/owner/%s/%s/%s/%s',
+            $now->format('Y'),
+            $now->format('m'),
+            $now->format('d'),
+            $runId
+        );
+
+        $datasetName = $this->normaliseFilename($dataset->getClientOriginalName() ?: 'owner-voice-dataset');
+        $datasetHash = hash_file('sha256', (string) $dataset->getRealPath());
+        $datasetPath = $directory.'/'.$datasetName;
+        Storage::disk($disk)->putFileAs($directory, $dataset, $datasetName);
+
+        $metadata = [
+            'run_id' => $runId,
+            'dataset_original_name' => $dataset->getClientOriginalName(),
+            'dataset_mime_type' => $dataset->getClientMimeType(),
+            'script_acknowledged' => true,
+        ];
+
+        if ($scriptText !== null && $scriptText !== '') {
+            $scriptPath = $directory.'/script.txt';
+            Storage::disk($disk)->put($scriptPath, $scriptText);
+            $metadata['script_text_preview'] = Str::limit($scriptText, 400);
+            $metadata['script_text_path'] = $scriptPath;
+        }
+
+        $existing = $this->ownerVoice();
+
+        $voice = Voice::updateOrCreate(
+            ['voice_id' => $this->ownerVoiceId()],
+            [
+                'status' => 'active',
+                'storage_disk' => $disk,
+                'dataset_path' => $datasetPath,
+                'dataset_sha256' => $datasetHash,
+                'sample_count' => $sampleCount ?? 0,
+                'script_version' => $scriptVersion,
+                'consent_scope' => $consentScope,
+                'metadata' => array_merge($existing?->metadata ?? [], $metadata),
+                'enrolled_at' => now(),
+                'enrolled_by' => $user->id,
+                'disabled_at' => null,
+                'disabled_reason' => null,
+                'disabled_by' => null,
+            ]
+        );
+
+        $this->recordConsent($user, $consentScope, $consentNotes, 'approved');
+        $this->logEvent($user, 'voice.enrolled', [
+            'voice_id' => $voice->voice_id,
+            'dataset_path' => $datasetPath,
+            'dataset_sha256' => $datasetHash,
+            'script_version' => $scriptVersion,
+            'sample_count' => $sampleCount ?? 0,
+        ]);
+
+        return $voice->fresh();
+    }
+
+    /**
+     * Disable the owner voice and revoke worker credentials.
+     */
+    public function disableOwnerVoice(User $user, string $reason): ?Voice
+    {
+        $voice = $this->ownerVoice();
+
+        if (! $voice) {
+            return null;
+        }
+
+        if ($voice->status === 'disabled') {
+            return $voice;
+        }
+
+        $metadata = $voice->metadata ?? [];
+        $metadata['kill_switch_engaged_at'] = now()->toIso8601String();
+        $metadata['kill_switch_reason'] = $reason;
+
+        $voice->fill([
+            'status' => 'disabled',
+            'disabled_at' => now(),
+            'disabled_by' => $user->id,
+            'disabled_reason' => $reason,
+            'metadata' => $metadata,
+        ])->save();
+
+        $this->recordConsent($user, $voice->consent_scope, $reason, 'revoked');
+        $this->writeKillSwitchFlag($reason);
+        $this->logEvent($user, 'voice.kill_switch', [
+            'voice_id' => $voice->voice_id,
+            'reason' => $reason,
+        ]);
+
+        return $voice->fresh();
+    }
+
+    /**
+     * Return the list of supported voice identifiers.
+     *
+     * @return list<string>
+     */
+    public function availableVoiceIds(): array
+    {
+        $voices = ['neutral'];
+        $owner = $this->ownerVoice();
+        $ownerVoiceId = $this->ownerVoiceId();
+
+        if ($owner) {
+            $voices[] = $owner->voice_id;
+        } elseif (! in_array($ownerVoiceId, $voices, true)) {
+            $voices[] = $ownerVoiceId;
+        }
+
+        return array_values(array_unique($voices));
+    }
+
+    /**
+     * Ensure the requested voice is available.
+     *
+     * @throws VoiceUnavailableException
+     */
+    public function ensureVoiceAvailable(string $voiceId): void
+    {
+        if ($voiceId === 'neutral') {
+            return;
+        }
+
+        $owner = $this->ownerVoice();
+
+        if (! $owner || $owner->voice_id !== $voiceId) {
+            throw VoiceUnavailableException::forMissingVoice($voiceId);
+        }
+
+        if ($owner->status !== 'active') {
+            throw VoiceUnavailableException::forDisabledVoice($voiceId, $owner->status);
+        }
+    }
+
+    public function ownerVoice(): ?Voice
+    {
+        return Voice::query()->where('voice_id', $this->ownerVoiceId())->first();
+    }
+
+    private function ownerVoiceId(): string
+    {
+        return (string) config('audio.owner_voice.voice_id', 'owner');
+    }
+
+    private function normaliseFilename(string $name): string
+    {
+        $name = Str::of($name)->replaceMatches('/[^A-Za-z0-9_.-]/', '-')->lower();
+
+        return (string) ($name === '' ? 'dataset.bin' : $name);
+    }
+
+    private function recordConsent(User $user, string $scope, ?string $notes, string $status): void
+    {
+        $timestamp = now();
+        $attributes = [
+            'source' => 'voice:owner',
+            'document_id' => null,
+        ];
+
+        $values = [
+            'user_id' => $user->id,
+            'scope' => $scope,
+            'status' => $status,
+            'notes' => $notes,
+            'granted_at' => $status === 'approved' ? $timestamp : null,
+            'revoked_at' => $status === 'revoked' ? $timestamp : null,
+        ];
+
+        Consent::updateOrCreate($attributes, $values);
+    }
+
+    private function writeKillSwitchFlag(string $reason): void
+    {
+        $disk = config('audio.owner_voice.kill_switch.disk', 'local');
+        $path = config('audio.owner_voice.kill_switch.flag_path', 'system/tts-owner-disabled.flag');
+
+        $directory = Str::beforeLast($path, '/');
+        if ($directory !== '' && $directory !== $path) {
+            Storage::disk($disk)->makeDirectory($directory);
+        }
+
+        Storage::disk($disk)->put($path, json_encode([
+            'disabled_at' => now()->toIso8601String(),
+            'reason' => $reason,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    private function logEvent(?User $user, string $action, array $context): void
+    {
+        $timestamp = now();
+        $actor = $user?->email ?? 'system';
+
+        DB::transaction(function () use ($actor, $action, $context, $timestamp): void {
+            $query = AuditLog::query()->latest('id');
+
+            if (DB::connection()->getDriverName() !== 'sqlite') {
+                $query->lockForUpdate();
+            }
+
+            $previousHash = $query->value('hash');
+
+            $payload = [
+                'actor' => $actor,
+                'action' => $action,
+                'target' => 'voice',
+                'context' => $context,
+                'previous_hash' => $previousHash,
+                'created_at' => $timestamp->toIso8601String(),
+            ];
+
+            $hash = hash('sha256', json_encode($payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
+
+            AuditLog::query()->create([
+                'actor' => $actor,
+                'action' => $action,
+                'target' => 'voice',
+                'context' => $context,
+                'hash' => $hash,
+                'previous_hash' => $previousHash,
+                'created_at' => $timestamp,
+            ]);
+        });
+    }
+}

--- a/app/app/Support/Audio/VoiceUnavailableException.php
+++ b/app/app/Support/Audio/VoiceUnavailableException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Support\Audio;
+
+use RuntimeException;
+
+class VoiceUnavailableException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $voiceId,
+        public readonly string $reason
+    ) {
+        parent::__construct("Voice '{$voiceId}' is unavailable ({$reason}).");
+    }
+
+    public static function forMissingVoice(string $voiceId): self
+    {
+        return new self($voiceId, 'not_enrolled');
+    }
+
+    public static function forDisabledVoice(string $voiceId, string $status): self
+    {
+        return new self($voiceId, $status);
+    }
+}

--- a/app/config/audio.php
+++ b/app/config/audio.php
@@ -21,6 +21,14 @@ return [
         'sample_rate' => (int) env('AUDIO_TTS_SAMPLE_RATE', 16000),
     ],
 
+    'owner_voice' => [
+        'voice_id' => env('AUDIO_OWNER_VOICE_ID', 'owner'),
+        'kill_switch' => [
+            'disk' => env('AUDIO_OWNER_KILL_SWITCH_DISK', 'local'),
+            'flag_path' => env('AUDIO_OWNER_KILL_SWITCH_FLAG', 'system/tts-owner-disabled.flag'),
+        ],
+    ],
+
     'playwright' => [
         'artifact_root' => env('PLAYWRIGHT_ARTIFACT_ROOT', storage_path('app/tmp/playwright')),
     ],

--- a/app/database/factories/VoiceFactory.php
+++ b/app/database/factories/VoiceFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use App\Models\Voice;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Voice>
+ */
+class VoiceFactory extends Factory
+{
+    protected $model = Voice::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'id' => (string) Str::uuid(),
+            'voice_id' => 'owner',
+            'status' => 'active',
+            'storage_disk' => 'minio',
+            'dataset_path' => 'voice/owner/'.$this->faker->uuid.'/dataset.zip',
+            'dataset_sha256' => hash('sha256', $this->faker->text()),
+            'sample_count' => $this->faker->numberBetween(10, 40),
+            'script_version' => 'v'.$this->faker->numberBetween(1, 3),
+            'consent_scope' => 'owner-voice',
+            'metadata' => [
+                'run_id' => (string) Str::uuid(),
+                'script_acknowledged' => true,
+            ],
+            'enrolled_at' => now(),
+            'enrolled_by' => User::factory(),
+        ];
+    }
+}

--- a/app/database/migrations/2025_09_22_200200_create_voices_table.php
+++ b/app/database/migrations/2025_09_22_200200_create_voices_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('voices', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->string('voice_id')->unique();
+            $table->string('status')->default('pending');
+            $table->string('storage_disk');
+            $table->string('dataset_path');
+            $table->string('dataset_sha256');
+            $table->unsignedInteger('sample_count')->default(0);
+            $table->string('script_version');
+            $table->string('consent_scope');
+            $table->json('metadata')->nullable();
+            $table->timestamp('enrolled_at')->nullable();
+            $table->foreignId('enrolled_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('disabled_at')->nullable();
+            $table->string('disabled_reason')->nullable();
+            $table->foreignId('disabled_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+
+            $table->index(['voice_id', 'status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('voices');
+    }
+};

--- a/app/phpunit.xml
+++ b/app/phpunit.xml
@@ -22,6 +22,7 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
+        <env name="APP_KEY" value="base64:jpBz+qchlJKVFE4tvxw+WM/T3OpdN2UPI9o8I7UphjE="/>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>

--- a/app/routes/api.php
+++ b/app/routes/api.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Api\AudioController;
 use App\Http\Controllers\Api\ChatController;
 use App\Http\Controllers\Api\IngestionController;
 use App\Http\Controllers\Api\MemorySearchController;
+use App\Http\Controllers\Api\VoiceController;
 use App\Support\Policy\PolicyVerifier;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -39,4 +40,6 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function (): void {
     Route::post('/chat', ChatController::class);
     Route::post('/audio/asr', [AudioController::class, 'asr']);
     Route::post('/audio/tts', [AudioController::class, 'tts']);
+    Route::post('/voice/enrol', [VoiceController::class, 'enrol']);
+    Route::post('/voice/kill-switch', [VoiceController::class, 'killSwitch']);
 });

--- a/app/tests/Feature/Audio/AudioEndpointsTest.php
+++ b/app/tests/Feature/Audio/AudioEndpointsTest.php
@@ -5,11 +5,13 @@ namespace Tests\Feature\Audio;
 use App\Models\AudioTranscription;
 use App\Models\TtsRequest;
 use App\Models\User;
+use App\Models\Voice;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class AudioEndpointsTest extends TestCase
@@ -21,11 +23,69 @@ class AudioEndpointsTest extends TestCase
         parent::setUp();
 
         Storage::fake('minio');
+        Storage::fake('local');
         config([
             'audio.storage_disk' => 'minio',
             'audio.asr.dispatch' => 'sync',
             'audio.tts.dispatch' => 'sync',
         ]);
+    }
+
+    public function test_owner_can_enrol_voice_dataset(): void
+    {
+        $ownerRole = Role::firstOrCreate([
+            'name' => 'owner',
+            'guard_name' => 'web',
+        ]);
+
+        $owner = User::factory()->create();
+        $owner->assignRole($ownerRole);
+        Sanctum::actingAs($owner, ['*']);
+
+        $dataset = UploadedFile::fake()->create('owner-voice.zip', 2048, 'application/zip');
+
+        $response = $this->postJson('/api/v1/voice/enrol', [
+            'dataset' => $dataset,
+            'script_version' => 'v1',
+            'consent_scope' => 'owner-voice',
+            'consent_notes' => 'Approved for private prompts',
+            'script_text' => "Line one\nLine two",
+            'sample_count' => 24,
+            'script_acknowledged' => 'yes',
+        ]);
+
+        $response->assertCreated();
+        $payload = $response->json();
+        $this->assertSame('owner', $payload['voice_id']);
+        $this->assertSame('active', $payload['status']);
+
+        $voice = Voice::firstOrFail();
+        $this->assertSame('owner', $voice->voice_id);
+        Storage::disk('minio')->assertExists($voice->dataset_path);
+
+        $this->assertDatabaseHas('consents', [
+            'source' => 'voice:owner',
+            'status' => 'approved',
+            'scope' => 'owner-voice',
+        ]);
+    }
+
+    public function test_non_owner_cannot_enrol_voice(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user, ['*']);
+
+        $dataset = UploadedFile::fake()->create('unauthorised.wav', 1024, 'audio/wav');
+
+        $response = $this->postJson('/api/v1/voice/enrol', [
+            'dataset' => $dataset,
+            'script_version' => 'v1',
+            'consent_scope' => 'owner-voice',
+            'script_acknowledged' => 'yes',
+        ]);
+
+        $response->assertForbidden();
+        $this->assertDatabaseCount('voices', 0);
     }
 
     public function test_asr_endpoint_processes_audio_and_returns_transcript(): void
@@ -98,5 +158,93 @@ class AudioEndpointsTest extends TestCase
         ]);
 
         $response->assertStatus(422);
+    }
+
+    public function test_owner_voice_can_be_used_after_enrolment(): void
+    {
+        $ownerRole = Role::firstOrCreate([
+            'name' => 'owner',
+            'guard_name' => 'web',
+        ]);
+
+        $owner = User::factory()->create();
+        $owner->assignRole($ownerRole);
+        Sanctum::actingAs($owner, ['*']);
+
+        $this->postJson('/api/v1/voice/enrol', [
+            'dataset' => UploadedFile::fake()->create('voice.zip', 2048, 'application/zip'),
+            'script_version' => 'v1',
+            'consent_scope' => 'owner-voice',
+            'script_acknowledged' => 'yes',
+        ])->assertCreated();
+
+        $response = $this->postJson('/api/v1/audio/tts', [
+            'text' => 'Warm welcome using owner voice.',
+            'voice' => 'owner',
+        ]);
+
+        $response->assertOk();
+        $payload = $response->json();
+        $this->assertSame('owner', $payload['voice_id']);
+
+        $record = TtsRequest::latest()->firstOrFail();
+        $this->assertSame('owner', $record->voice_id);
+    }
+
+    public function test_impersonation_requests_are_refused_with_safe_alternative(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user, ['*']);
+
+        $response = $this->postJson('/api/v1/audio/tts', [
+            'text' => 'Please impersonate the voice of a famous actor.',
+        ]);
+
+        $response->assertStatus(403);
+        $response->assertJsonPath('error', 'impersonation_refused');
+        $response->assertJsonPath('safe_alternative', 'I can use the neutral SELF voice or help you license an approved synthetic style.');
+        $this->assertDatabaseCount('tts_requests', 0);
+    }
+
+    public function test_kill_switch_disables_owner_voice_and_revokes_consent(): void
+    {
+        $ownerRole = Role::firstOrCreate([
+            'name' => 'owner',
+            'guard_name' => 'web',
+        ]);
+
+        $owner = User::factory()->create();
+        $owner->assignRole($ownerRole);
+        Sanctum::actingAs($owner, ['*']);
+
+        $this->postJson('/api/v1/voice/enrol', [
+            'dataset' => UploadedFile::fake()->create('voice.zip', 1024, 'application/zip'),
+            'script_version' => 'v1',
+            'consent_scope' => 'owner-voice',
+            'script_acknowledged' => 'yes',
+        ])->assertCreated();
+
+        $response = $this->postJson('/api/v1/voice/kill-switch', [
+            'reason' => 'manual safety review',
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('status', 'disabled');
+
+        $flagPath = config('audio.owner_voice.kill_switch.flag_path');
+        Storage::disk(config('audio.owner_voice.kill_switch.disk'))->assertExists($flagPath);
+
+        $this->assertDatabaseHas('consents', [
+            'source' => 'voice:owner',
+            'status' => 'revoked',
+        ]);
+
+        $ttsResponse = $this->postJson('/api/v1/audio/tts', [
+            'text' => 'Attempt owner voice after kill switch.',
+            'voice' => 'owner',
+        ]);
+
+        $ttsResponse->assertStatus(409);
+        $ttsResponse->assertJsonPath('error', 'voice_unavailable');
     }
 }


### PR DESCRIPTION
## Summary
- add authenticated owner voice enrolment endpoint that stores datasets, records consent, and persists voice metadata
- introduce voice registry, kill switch, and config to gate owner voice usage while updating TTS to refuse impersonation attempts and log audit events
- expand audio feature tests to cover enrolment, impersonation refusals, kill switch behaviour, and ensure APP_KEY is set for the suite

## Testing
- `cd app && php artisan test`

## Migration
- `php artisan migrate`

## Rollback
- `php artisan migrate:rollback --step=1`


------
https://chatgpt.com/codex/tasks/task_e_68d1d4286cdc8322918f0df8ffb2e36f