### PR TITLE
docs: mark ingestion milestone complete

### DIFF
--- a/SELF-README.md
+++ b/SELF-README.md
@@ -126,11 +126,11 @@ Then the app fails to boot and returns a clear error on /health
 ### M1 — Ingestion & Consent
 **Goal:** Bring data in deliberately; approve/reject before indexing.
 
-- [ ] Endpoints: `POST /v1/ingest/text`, `POST /v1/ingest/file` (PDF/audio).  
-- [ ] Review queue UI: approve/reject with reason; record consent scope per source.  
-- [ ] PII scrubbing pipeline (basic: emails, phones) with bypass flag (owner only).  
-- [ ] Source tagging, retention classes; `DELETE` for right‑to‑forget (by source/doc).  
-- [ ] Store originals in MinIO with versioning; record SHA‑256 & metadata.
+- [x] Endpoints: `POST /v1/ingest/text`, `POST /v1/ingest/file` (PDF/audio).  
+- [x] Review queue UI: approve/reject with reason; record consent scope per source.  
+- [x] PII scrubbing pipeline (basic: emails, phones) with bypass flag (owner only).  
+- [x] Source tagging, retention classes; `DELETE` for right‑to‑forget (by source/doc).  
+- [x] Store originals in MinIO with versioning; record SHA‑256 & metadata.
 
 **Acceptance:**
 ```


### PR DESCRIPTION
## Summary
- mark the M1 ingestion & consent milestone checklist as complete now that ingestion endpoints, review flow, and consent controls are in place

## Testing
- `cd app && CACHE_STORE=array CACHE_DRIVER=array QUEUE_CONNECTION=sync SESSION_DRIVER=array REDIS_CLIENT=array php artisan test`

## MIGRATION
- not required

## ROLLBACK
- revert the README checkbox updates

------
https://chatgpt.com/codex/tasks/task_e_68d24f40a6dc8322bc8acfa730667b2a