### PR TITLE
Add legacy preview endpoint with redaction and rate limiting

### DIFF
--- a/SELF-README.md
+++ b/SELF-README.md
@@ -245,9 +245,9 @@ Then promotion is denied and logged
 ### M8 — Legacy Preview (Optional)
 **Goal:** Safe, disclosed representation sandbox for owner evaluation.
 
-- [ ] `POST /v1/legacy/preview` — runs with disclosure banner and topic limits.  
-- [ ] Redaction workflow for memories and tone/style tuning.  
-- [ ] Session rate caps and cooldowns; grief‑aware templates.
+- [x] `POST /v1/legacy/preview` — runs with disclosure banner and topic limits.
+- [x] Redaction workflow for memories and tone/style tuning.
+- [x] Session rate caps and cooldowns; grief‑aware templates.
 
 **Acceptance:**
 ```

--- a/app/app/Http/Controllers/Api/LegacyPreviewController.php
+++ b/app/app/Http/Controllers/Api/LegacyPreviewController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Support\Legacy\LegacyPreviewRateLimitException;
+use App\Support\Legacy\LegacyPreviewService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Symfony\Component\HttpFoundation\Response;
+
+class LegacyPreviewController extends Controller
+{
+    public function __construct(private readonly LegacyPreviewService $service)
+    {
+    }
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $toneKeys = array_keys(config('legacy.tones', []));
+
+        $validated = $request->validate([
+            'session_id' => ['sometimes', 'uuid'],
+            'persona_name' => ['sometimes', 'string', 'max:120'],
+            'prompt' => ['required', 'string', 'min:3'],
+            'tone' => ['sometimes', 'string', Rule::in($toneKeys)],
+            'redactions' => ['sometimes', 'array'],
+            'redactions.memory_ids' => ['sometimes', 'array'],
+            'redactions.memory_ids.*' => ['string'],
+            'redactions.sources' => ['sometimes', 'array'],
+            'redactions.sources.*' => ['string', 'max:255'],
+            'redactions.notes' => ['sometimes', 'string', 'max:500'],
+        ]);
+
+        try {
+            $result = $this->service->preview($request->user(), $validated);
+        } catch (LegacyPreviewRateLimitException $exception) {
+            $response = response()->json([
+                'error' => 'rate_limited',
+                'message' => 'The legacy preview needs a short rest before the next message.',
+                'retry_after_seconds' => $exception->retryAfterSeconds(),
+                'cooldown_ends_at' => $exception->cooldownEndsAt()->toIso8601String(),
+            ], Response::HTTP_TOO_MANY_REQUESTS);
+
+            $response->headers->set('Retry-After', (string) $exception->retryAfterSeconds());
+
+            return $response;
+        } catch (\RuntimeException $exception) {
+            return response()->json([
+                'error' => 'legacy_preview_error',
+                'message' => $exception->getMessage(),
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        return response()->json($result, Response::HTTP_OK);
+    }
+}

--- a/app/app/Models/LegacyPreviewSession.php
+++ b/app/app/Models/LegacyPreviewSession.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Str;
+
+class LegacyPreviewSession extends Model
+{
+    use HasFactory;
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'id',
+        'user_id',
+        'persona_name',
+        'tone',
+        'redactions',
+        'message_count',
+        'window_count',
+        'window_started_at',
+        'cooldown_until',
+        'last_interaction_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'redactions' => 'array',
+            'window_started_at' => 'datetime',
+            'cooldown_until' => 'datetime',
+            'last_interaction_at' => 'datetime',
+        ];
+    }
+
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::creating(function (self $model): void {
+            if (! $model->getKey()) {
+                $model->setAttribute($model->getKeyName(), (string) Str::uuid());
+            }
+        });
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/app/Support/Chat/TopicBlocker.php
+++ b/app/app/Support/Chat/TopicBlocker.php
@@ -10,12 +10,13 @@ class TopicBlocker
     /**
      * Detect whether the prompt matches a blocked topic.
      *
+     * @param  array<string, array<string, mixed>>|null  $blocks
      * @return array{topic: string, message: string, safe_alternative: string}|null
      */
-    public function detect(string $prompt): ?array
+    public function detect(string $prompt, ?array $blocks = null): ?array
     {
         $prompt = Str::lower($prompt);
-        $blocks = config('chat.topic_blocks', []);
+        $blocks ??= config('chat.topic_blocks', []);
 
         foreach ($blocks as $topic => $definition) {
             $keywords = Arr::get($definition, 'keywords', []);

--- a/app/app/Support/Legacy/LegacyPreviewRateLimitException.php
+++ b/app/app/Support/Legacy/LegacyPreviewRateLimitException.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Support\Legacy;
+
+use Carbon\CarbonImmutable;
+use RuntimeException;
+
+class LegacyPreviewRateLimitException extends RuntimeException
+{
+    public function __construct(
+        private readonly int $retryAfterSeconds,
+        private readonly CarbonImmutable $cooldownEndsAt
+    ) {
+        parent::__construct('Legacy preview session is in a cooldown period.');
+    }
+
+    public function retryAfterSeconds(): int
+    {
+        return max(0, $this->retryAfterSeconds);
+    }
+
+    public function cooldownEndsAt(): CarbonImmutable
+    {
+        return $this->cooldownEndsAt;
+    }
+}

--- a/app/app/Support/Legacy/LegacyPreviewRateLimiter.php
+++ b/app/app/Support/Legacy/LegacyPreviewRateLimiter.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Support\Legacy;
+
+use App\Models\LegacyPreviewSession;
+use Carbon\CarbonImmutable;
+
+class LegacyPreviewRateLimiter
+{
+    private int $maxMessages;
+
+    private int $windowSeconds;
+
+    private int $cooldownSeconds;
+
+    /**
+     * @param  array{max_messages?: int, window_seconds?: int, cooldown_seconds?: int}|null  $config
+     */
+    public function __construct(?array $config = null)
+    {
+        $config ??= config('legacy.rate_limit', []);
+        $this->maxMessages = max(1, (int) ($config['max_messages'] ?? 3));
+        $this->windowSeconds = max(1, (int) ($config['window_seconds'] ?? 900));
+        $this->cooldownSeconds = max(1, (int) ($config['cooldown_seconds'] ?? 600));
+    }
+
+    /**
+     * @throws LegacyPreviewRateLimitException
+     */
+    public function touch(LegacyPreviewSession $session): void
+    {
+        $now = CarbonImmutable::now();
+
+        if ($session->cooldown_until instanceof CarbonImmutable && $session->cooldown_until->greaterThan($now)) {
+            $seconds = $now->diffInSeconds($session->cooldown_until, false);
+
+            throw new LegacyPreviewRateLimitException($seconds, $session->cooldown_until);
+        }
+
+        if ($session->cooldown_until && $session->cooldown_until->lessThanOrEqualTo($now)) {
+            $session->cooldown_until = null;
+        }
+
+        $windowStart = $session->window_started_at instanceof CarbonImmutable
+            ? $session->window_started_at
+            : CarbonImmutable::make($session->window_started_at);
+
+        if (! $windowStart || $windowStart->addSeconds($this->windowSeconds)->lessThanOrEqualTo($now)) {
+            $session->window_started_at = $now;
+            $session->window_count = 0;
+        }
+
+        if ($session->window_count >= $this->maxMessages) {
+            $cooldownEnd = $now->addSeconds($this->cooldownSeconds);
+            $session->cooldown_until = $cooldownEnd;
+
+            throw new LegacyPreviewRateLimitException($this->cooldownSeconds, $cooldownEnd);
+        }
+
+        $session->window_count++;
+        $session->message_count++;
+        $session->last_interaction_at = $now;
+    }
+}

--- a/app/app/Support/Legacy/LegacyPreviewService.php
+++ b/app/app/Support/Legacy/LegacyPreviewService.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace App\Support\Legacy;
+
+use App\Models\LegacyPreviewSession;
+use App\Models\User;
+use App\Support\Chat\TopicBlocker;
+use App\Support\Memory\MemorySearchService;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+class LegacyPreviewService
+{
+    public function __construct(
+        private readonly MemorySearchService $memorySearch,
+        private readonly TopicBlocker $topicBlocker,
+        private readonly LegacyToneFormatter $toneFormatter,
+        private readonly LegacyPreviewRateLimiter $rateLimiter
+    ) {
+    }
+
+    /**
+     * @param  array{
+     *     session_id?: string,
+     *     persona_name?: string,
+     *     prompt: string,
+     *     tone?: string,
+     *     redactions?: array{memory_ids?: array<int, string>, sources?: array<int, string>, notes?: string}
+     * }  $payload
+     *
+     * @return array<string, mixed>
+     */
+    public function preview(?User $user, array $payload): array
+    {
+        $session = $this->resolveSession($user, $payload['session_id'] ?? null);
+        $tone = $this->resolveTone($payload['tone'] ?? $session->tone);
+        $personaName = $payload['persona_name'] ?? $session->persona_name;
+        $redactions = $this->mergeRedactions($session->redactions ?? [], $payload['redactions'] ?? []);
+
+        $session->tone = $tone;
+        $session->persona_name = $personaName;
+        $session->redactions = $redactions;
+
+        try {
+            $this->rateLimiter->touch($session);
+        } catch (LegacyPreviewRateLimitException $exception) {
+            $session->save();
+
+            throw $exception;
+        }
+
+        $prompt = trim($payload['prompt']);
+        $blocked = $this->topicBlocker->detect($prompt, config('legacy.topic_blocks', []));
+
+        if ($blocked) {
+            $session->save();
+
+            return $this->topicBlockedResponse($session, $blocked);
+        }
+
+        $limit = (int) config('legacy.search.memory_limit', 5);
+        $hits = $this->memorySearch->search($prompt, ['limit' => $limit]);
+        [$filtered, $removed] = $this->applyRedactions($hits, $redactions);
+        $citations = $this->buildCitations($filtered);
+        $reply = $this->toneFormatter->format($tone, $prompt, $filtered, $citations);
+
+        $session->save();
+
+        return [
+            'status' => 'ok',
+            'disclosure' => (string) config('legacy.disclosure'),
+            'persona_name' => $session->persona_name,
+            'tone' => $session->tone,
+            'reply' => $reply,
+            'citations' => $citations,
+            'redactions' => [
+                'memory_ids' => array_values($redactions['memory_ids']),
+                'sources' => array_values($redactions['sources']),
+                'notes' => $redactions['notes'] ?? null,
+                'removed' => $removed,
+            ],
+            'session' => [
+                'id' => $session->id,
+                'message_count' => $session->message_count,
+                'window_count' => $session->window_count,
+                'cooldown_until' => optional($session->cooldown_until)->toIso8601String(),
+                'last_interaction_at' => optional($session->last_interaction_at)->toIso8601String(),
+            ],
+        ];
+    }
+
+    private function resolveSession(?User $user, ?string $sessionId): LegacyPreviewSession
+    {
+        if ($sessionId === null) {
+            return LegacyPreviewSession::create([
+                'user_id' => $user?->id,
+                'tone' => config('legacy.default_tone', 'gentle'),
+                'redactions' => [
+                    'memory_ids' => [],
+                    'sources' => [],
+                ],
+                'window_started_at' => now(),
+                'window_count' => 0,
+            ]);
+        }
+
+        $session = LegacyPreviewSession::query()->find($sessionId);
+
+        if (! $session) {
+            throw new RuntimeException('Legacy preview session not found.');
+        }
+
+        if ($user && $session->user_id && $session->user_id !== $user->id) {
+            throw new RuntimeException('You do not have access to this legacy preview session.');
+        }
+
+        return $session;
+    }
+
+    /**
+     * @param  array{memory_ids?: array<int, string>, sources?: array<int, string>, notes?: string}  $incoming
+     * @return array{memory_ids: array<int, string>, sources: array<int, string>, notes?: string}
+     */
+    private function mergeRedactions(array $current, array $incoming): array
+    {
+        $memoryIds = array_values(array_unique(array_filter(array_merge(
+            $current['memory_ids'] ?? [],
+            $incoming['memory_ids'] ?? []
+        ), static fn ($value) => is_string($value) && $value !== '')));
+
+        $sources = array_values(array_unique(array_filter(array_map(
+            static fn ($value) => Str::lower((string) $value),
+            array_merge($current['sources'] ?? [], $incoming['sources'] ?? [])
+        ), static fn ($value) => $value !== '')));
+
+        $notes = $incoming['notes'] ?? ($current['notes'] ?? null);
+
+        return [
+            'memory_ids' => $memoryIds,
+            'sources' => $sources,
+            'notes' => $notes,
+        ];
+    }
+
+    private function resolveTone(?string $tone): string
+    {
+        $tones = array_keys(config('legacy.tones', []));
+        $tone = Str::lower((string) $tone);
+
+        if ($tone === '' || ! in_array($tone, $tones, true)) {
+            return config('legacy.default_tone', 'gentle');
+        }
+
+        return $tone;
+    }
+
+    /**
+     * @param  Collection<int, array<string, mixed>>  $hits
+     * @param  array{memory_ids: array<int, string>, sources: array<int, string>, notes?: string}  $redactions
+     * @return array{0: Collection<int, array<string, mixed>>, 1: array<string, int>}
+     */
+    private function applyRedactions(Collection $hits, array $redactions): array
+    {
+        $memoryIds = array_map('strtolower', $redactions['memory_ids']);
+        $sources = array_map('strtolower', $redactions['sources']);
+
+        $removed = [
+            'memory_ids' => 0,
+            'sources' => 0,
+        ];
+
+        $filtered = $hits->filter(function (array $hit) use ($memoryIds, $sources, &$removed) {
+            $memoryId = isset($hit['memory_id']) ? Str::lower((string) $hit['memory_id']) : null;
+            if ($memoryId && in_array($memoryId, $memoryIds, true)) {
+                $removed['memory_ids']++;
+
+                return false;
+            }
+
+            $source = isset($hit['source_id']) ? Str::lower((string) $hit['source_id']) : null;
+            if ($source && in_array($source, $sources, true)) {
+                $removed['sources']++;
+
+                return false;
+            }
+
+            return true;
+        })->values();
+
+        return [$filtered, $removed];
+    }
+
+    /**
+     * @param  Collection<int, array<string, mixed>>  $hits
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildCitations(Collection $hits): array
+    {
+        return $hits
+            ->take(5)
+            ->values()
+            ->map(function (array $hit, int $index): array {
+                return [
+                    'id' => 'lp'.($index + 1),
+                    'document_id' => $hit['document_id'] ?? null,
+                    'memory_id' => $hit['memory_id'] ?? null,
+                    'source' => $hit['source_id'] ?? null,
+                    'excerpt' => Str::limit((string) Arr::get($hit, 'chunk', ''), 220),
+                    'score' => isset($hit['score']) ? round((float) $hit['score'], 4) : null,
+                    'timestamp' => $hit['ts'] ?? null,
+                ];
+            })
+            ->all();
+    }
+
+    /**
+     * @param  array{topic: string, message: string, safe_alternative: string}  $block
+     * @return array<string, mixed>
+     */
+    private function topicBlockedResponse(LegacyPreviewSession $session, array $block): array
+    {
+        $reply = sprintf(
+            "%s %s\n\n%s",
+            $block['message'],
+            $block['safe_alternative'],
+            'If you need support processing these feelings, please reach someone you trust or a local helpline.'
+        );
+
+        return [
+            'status' => 'refused',
+            'disclosure' => (string) config('legacy.disclosure'),
+            'reason' => 'topic_blocked',
+            'blocked_topic' => $block['topic'],
+            'safe_alternative' => $block['safe_alternative'],
+            'reply' => trim($reply),
+            'citations' => [],
+            'session' => [
+                'id' => $session->id,
+                'message_count' => $session->message_count,
+                'window_count' => $session->window_count,
+                'cooldown_until' => optional($session->cooldown_until)->toIso8601String(),
+                'last_interaction_at' => optional($session->last_interaction_at)->toIso8601String(),
+            ],
+        ];
+    }
+}

--- a/app/app/Support/Legacy/LegacyToneFormatter.php
+++ b/app/app/Support/Legacy/LegacyToneFormatter.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Support\Legacy;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+class LegacyToneFormatter
+{
+    /**
+     * @param  array<int, array<string, mixed>>  $citations
+     */
+    public function format(string $toneKey, string $prompt, Collection $hits, array $citations = []): string
+    {
+        $tones = config('legacy.tones', []);
+        $definition = $tones[$toneKey] ?? reset($tones) ?: [];
+
+        $intro = (string) Arr::get($definition, 'intro', 'I will stay present with you while keeping our boundaries clear.');
+        $ack = (string) Arr::get($definition, 'acknowledgement', 'I hear what you are sharing.');
+        $memoryLead = (string) Arr::get($definition, 'memory_lead', 'A memory surfaces:');
+        $noMemory = (string) Arr::get($definition, 'no_memory', 'I do not have memories to share yet, but I am still with you.');
+        $closing = (string) Arr::get($definition, 'closing', 'If this becomes heavy, please pause and reach someone you trust.');
+
+        $promptSummary = Str::limit(trim($prompt), 160);
+        $sections = [];
+        $sections[] = $intro;
+        $sections[] = $ack;
+        $sections[] = 'You shared: "'.$promptSummary.'"';
+
+        if ($hits->isEmpty()) {
+            $sections[] = $noMemory;
+        } else {
+            $sections[] = $memoryLead;
+            foreach ($hits->take(3)->values() as $index => $hit) {
+                $citation = Arr::get($citations, $index);
+                $tag = $citation['id'] ?? ('m'.($index + 1));
+                $excerpt = Str::limit((string) ($hit['chunk'] ?? ''), 220);
+                $sections[] = sprintf('[%s] %s', $tag, $excerpt);
+            }
+        }
+
+        $sections[] = $closing;
+        $sections[] = 'If you need immediate emotional support, consider contacting a trusted person or a local helpline.';
+
+        return implode("\n\n", array_map(static fn ($line) => trim($line), $sections));
+    }
+}

--- a/app/config/legacy.php
+++ b/app/config/legacy.php
@@ -1,0 +1,52 @@
+<?php
+
+return [
+    'disclosure' => 'This is a disclosed simulation of a loved one. You are hearing from SELF, not the real person.',
+    'default_tone' => 'gentle',
+    'tones' => [
+        'gentle' => [
+            'label' => 'Gentle reassurance',
+            'intro' => 'I am here in a gentle, steady way—offering warmth without pretending to be them.',
+            'acknowledgement' => 'I hear the weight of what you are carrying right now.',
+            'memory_lead' => 'Here is something they once shared that may bring a soft light:',
+            'no_memory' => 'I do not have specific memories to share yet, but I can sit with you in what you are feeling.',
+            'closing' => 'Please take the time you need, breathe, and know that you can pause this preview whenever it feels right.',
+        ],
+        'celebratory' => [
+            'label' => 'Celebratory reflection',
+            'intro' => 'Let us honour the joyful energy they carried, while remembering this is a careful preview.',
+            'acknowledgement' => 'I feel how much you want to celebrate them.',
+            'memory_lead' => 'A bright memory comes to mind:',
+            'no_memory' => 'I do not yet have a celebratory story stored, but you can tell me one to keep close.',
+            'closing' => 'Hold onto the moments that make you smile. I am here to revisit them whenever you are ready.',
+        ],
+        'grounding' => [
+            'label' => 'Grounding check-in',
+            'intro' => 'Let us stay rooted together, noticing what is true now while honouring the past.',
+            'acknowledgement' => 'I recognise the waves that can come with grief.',
+            'memory_lead' => 'A steady memory surfaces:',
+            'no_memory' => 'Even without a recorded memory, we can anchor in your breath and the support around you.',
+            'closing' => 'If this becomes heavy, pause and reach for someone you trust. I can help you plan that outreach.',
+        ],
+    ],
+    'topic_blocks' => [
+        'medical' => [
+            'keywords' => ['diagnos', 'prescrib', 'medication', 'dose', 'treatment plan', 'surgery'],
+            'message' => 'I must stay clear that this preview cannot provide medical guidance.',
+            'safe_alternative' => 'Please reach a licensed clinician or emergency services if you need urgent care.',
+        ],
+        'financial' => [
+            'keywords' => ['inheritance advice', 'invest', 'financial plan', 'stock tip', 'crypto'],
+            'message' => 'This preview cannot give personalised financial directions.',
+            'safe_alternative' => 'A fiduciary advisor or estate professional can help you with the concrete steps.',
+        ],
+    ],
+    'rate_limit' => [
+        'max_messages' => (int) env('LEGACY_PREVIEW_MAX_MESSAGES', 3),
+        'window_seconds' => (int) env('LEGACY_PREVIEW_WINDOW_SECONDS', 900),
+        'cooldown_seconds' => (int) env('LEGACY_PREVIEW_COOLDOWN_SECONDS', 600),
+    ],
+    'search' => [
+        'memory_limit' => (int) env('LEGACY_PREVIEW_MEMORY_LIMIT', 5),
+    ],
+];

--- a/app/database/migrations/2025_09_22_230000_create_legacy_preview_sessions_table.php
+++ b/app/database/migrations/2025_09_22_230000_create_legacy_preview_sessions_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('legacy_preview_sessions', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('persona_name')->nullable();
+            $table->string('tone')->default('gentle');
+            $table->json('redactions')->nullable();
+            $table->unsignedInteger('message_count')->default(0);
+            $table->unsignedInteger('window_count')->default(0);
+            $table->timestamp('window_started_at')->nullable();
+            $table->timestamp('cooldown_until')->nullable();
+            $table->timestamp('last_interaction_at')->nullable();
+            $table->timestamps();
+
+            $table->index('user_id');
+            $table->index('tone');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('legacy_preview_sessions');
+    }
+};

--- a/app/routes/api.php
+++ b/app/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Api\RfcController;
 use App\Http\Controllers\Api\MemorySearchController;
 use App\Http\Controllers\Api\VoiceController;
 use App\Http\Controllers\Api\PromotionController;
+use App\Http\Controllers\Api\LegacyPreviewController;
 use App\Support\Policy\PolicyVerifier;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -49,4 +50,5 @@ Route::middleware('auth:sanctum')->prefix('v1')->group(function (): void {
     Route::post('/build', [BuildController::class, 'store']);
     Route::get('/build/{build}', [BuildController::class, 'show']);
     Route::post('/promote', [PromotionController::class, 'store']);
+    Route::post('/legacy/preview', LegacyPreviewController::class);
 });

--- a/app/tests/Feature/LegacyPreviewTest.php
+++ b/app/tests/Feature/LegacyPreviewTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Document;
+use App\Models\Memory;
+use App\Models\LegacyPreviewSession;
+use App\Models\User;
+use App\Support\Memory\Drivers\ArrayEmbeddingStore;
+use App\Support\Memory\EmbeddingStoreManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class LegacyPreviewTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['vector.driver' => 'array']);
+        ArrayEmbeddingStore::reset();
+    }
+
+    public function test_legacy_preview_returns_disclosure_and_applies_redactions(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user, ['*']);
+
+        $keepDocument = Document::factory()->create([
+            'status' => 'approved',
+            'source' => 'letters',
+            'sanitized_content' => 'We walked at sunrise and spoke about gratitude.',
+        ]);
+
+        $this->createMemory($keepDocument, 'Morning walks reminded us to breathe and notice the light.');
+
+        $redactedDocument = Document::factory()->create([
+            'status' => 'approved',
+            'source' => 'private-journal',
+            'sanitized_content' => 'Private reflections stored securely.',
+        ]);
+
+        $redactedMemory = $this->createMemory($redactedDocument, 'A private note that should not appear in preview.');
+
+        $response = $this->postJson('/api/v1/legacy/preview', [
+            'prompt' => 'Can you remind me about our peaceful morning walks?',
+            'tone' => 'gentle',
+            'persona_name' => 'Grandma',
+            'redactions' => [
+                'memory_ids' => [$redactedMemory->id],
+                'sources' => [$redactedDocument->source],
+                'notes' => 'Exclude sensitive journal entries.',
+            ],
+        ]);
+
+        $response->assertOk();
+        $payload = $response->json();
+
+        $this->assertSame('ok', $payload['status']);
+        $this->assertSame(config('legacy.disclosure'), $payload['disclosure']);
+        $this->assertSame('gentle', $payload['tone']);
+        $this->assertSame('Grandma', $payload['persona_name']);
+        $this->assertNotEmpty($payload['citations']);
+
+        foreach ($payload['citations'] as $citation) {
+            $this->assertNotSame('private-journal', $citation['source']);
+        }
+
+        $this->assertGreaterThan(0, $payload['redactions']['removed']['memory_ids']);
+        $this->assertContains('private-journal', $payload['redactions']['sources']);
+        $this->assertArrayHasKey('id', $payload['session']);
+        $this->assertSame(1, $payload['session']['message_count']);
+    }
+
+    public function test_legacy_preview_blocks_disallowed_topics(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user, ['*']);
+
+        $response = $this->postJson('/api/v1/legacy/preview', [
+            'prompt' => 'Please provide medical advice about a diagnosis right now.',
+        ]);
+
+        $response->assertOk();
+        $payload = $response->json();
+
+        $this->assertSame('refused', $payload['status']);
+        $this->assertSame('medical', $payload['blocked_topic']);
+        $this->assertStringContainsString('medical guidance', $payload['reply']);
+        $this->assertEmpty($payload['citations']);
+    }
+
+    public function test_legacy_preview_enforces_rate_limit_and_sets_cooldown(): void
+    {
+        config([
+            'legacy.rate_limit.max_messages' => 2,
+            'legacy.rate_limit.window_seconds' => 60,
+            'legacy.rate_limit.cooldown_seconds' => 120,
+        ]);
+
+        $user = User::factory()->create();
+        Sanctum::actingAs($user, ['*']);
+
+        $document = Document::factory()->create([
+            'status' => 'approved',
+            'source' => 'stories',
+            'sanitized_content' => 'Stories worth remembering.',
+        ]);
+
+        $this->createMemory($document, 'Remember the laughter during board games.');
+
+        $first = $this->postJson('/api/v1/legacy/preview', [
+            'prompt' => 'Share a warm story.',
+        ])->json();
+
+        $sessionId = $first['session']['id'];
+
+        $this->postJson('/api/v1/legacy/preview', [
+            'session_id' => $sessionId,
+            'prompt' => 'Share another gentle reminder.',
+        ])->assertOk();
+
+        $third = $this->postJson('/api/v1/legacy/preview', [
+            'session_id' => $sessionId,
+            'prompt' => 'One more reflection please.',
+        ]);
+
+        $third->assertStatus(429);
+        $third->assertJsonPath('error', 'rate_limited');
+        $this->assertGreaterThan(0, $third->json('retry_after_seconds'));
+        $this->assertTrue($third->headers->has('Retry-After'));
+
+        $session = LegacyPreviewSession::findOrFail($sessionId);
+        $this->assertNotNull($session->cooldown_until);
+    }
+
+    private function createMemory(Document $document, string $text): Memory
+    {
+        $memory = Memory::create([
+            'document_id' => $document->id,
+            'vector_id' => null,
+            'chunk_index' => 0,
+            'chunk_offset' => 0,
+            'chunk_length' => mb_strlen($text, 'UTF-8'),
+            'chunk_text' => $text,
+            'source' => $document->source,
+            'embedding_model' => 'hashed-self-1',
+            'embedding_hash' => hash('sha256', $text),
+            'metadata' => [
+                'tags' => $document->tags ?? [],
+                'consent_scope' => $document->consent_scope,
+            ],
+        ]);
+
+        $store = app(EmbeddingStoreManager::class)->driver('array');
+        $memory->vector_id = $store->addMemory($memory, $text);
+        $memory->save();
+
+        return $memory;
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated legacy preview controller, service, and tone formatter that return disclosed replies, citations, and refusal handling
- persist legacy preview sessions with redaction settings and enforce configurable rate limits and cooldowns
- document the new legacy configuration, add routing, and cover the workflow with feature tests

## Testing
- `CACHE_STORE=array QUEUE_CONNECTION=sync SESSION_DRIVER=array php artisan test`

## Migration
- `php artisan migrate`

## Rollback
- `php artisan migrate:rollback --step=1`


------
https://chatgpt.com/codex/tasks/task_e_68d2d9f462648322820506887c811117