### PR TITLE
Add unit test for invalid immutable policy signatures

### DIFF
--- a/app/tests/Unit/PolicyVerifierTest.php
+++ b/app/tests/Unit/PolicyVerifierTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\Policy\PolicyVerifier;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Tests\TestCase;
+
+class PolicyVerifierTest extends TestCase
+{
+    public function test_verify_throws_when_signature_invalid(): void
+    {
+        $originalConfig = config('policy');
+        $cacheStore = $originalConfig['cache_store'] ?? config('cache.default', 'array');
+
+        $invalidSignaturePath = base_path('storage/framework/testing/policy/immutable-policy.sig');
+        File::ensureDirectoryExists(dirname($invalidSignaturePath));
+        File::put($invalidSignaturePath, base64_encode('totally-invalid-signature'));
+
+        config([
+            'policy.signature_path' => 'storage/framework/testing/policy/immutable-policy.sig',
+        ]);
+
+        Cache::store($cacheStore)->forget('policy:immutable:verification');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Immutable policy signature verification failed.');
+
+        try {
+            app(PolicyVerifier::class)->verify();
+        } finally {
+            config([
+                'policy.signature_path' => $originalConfig['signature_path'] ?? 'policy/immutable-policy.sig',
+            ]);
+
+            Cache::store($cacheStore)->forget('policy:immutable:verification');
+            File::delete($invalidSignaturePath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a unit test covering PolicyVerifier failure when the immutable policy signature is tampered

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container environment)*

## MIGRATION
- n/a

## ROLLBACK
- revert this commit to remove the additional unit test


------
https://chatgpt.com/codex/tasks/task_e_68dede6f73908322a440a266049db613