### PR TITLE
Add Docker development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Docker build context exclusions
+.git
+.gitmodules
+.github
+node_modules
+app/node_modules
+app/vendor
+verifier/__pycache__
+worker-embed/__pycache__
+worker-asr/__pycache__
+worker-tts/__pycache__
+**/__pycache__
+*.log
+storage
+app/storage/app/tmp
+app/storage/framework/cache
+app/storage/framework/sessions
+app/storage/framework/views
+app/storage/logs
+.env
+app/.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+# syntax=docker/dockerfile:1.6
+
+FROM php:8.2-fpm-bookworm AS base
+
+# Install system dependencies and PHP extensions
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        unzip \
+        curl \
+        ca-certificates \
+        libicu-dev \
+        libzip-dev \
+        libpng-dev \
+        libonig-dev \
+        libxml2-dev \
+        libsqlite3-dev \
+        sqlite3 \
+        supervisor \
+    && docker-php-ext-configure intl \
+    && docker-php-ext-install \
+        bcmath \
+        intl \
+        pcntl \
+        pdo \
+        pdo_mysql \
+        pdo_pgsql \
+        pdo_sqlite \
+        zip \
+    && pecl install redis \
+    && docker-php-ext-enable redis \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 20.x
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy Composer from the official image
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /var/www/html
+
+# Copy application code
+COPY app/ ./
+
+# Prepare runtime directories
+RUN mkdir -p storage bootstrap/cache \
+    && chown -R www-data:www-data storage bootstrap/cache
+
+# Copy the entrypoint script
+COPY docker/entrypoint.sh /usr/local/bin/app-entrypoint
+RUN chmod +x /usr/local/bin/app-entrypoint
+
+ENV PATH="/var/www/html/vendor/bin:${PATH}"
+
+EXPOSE 8000 5173
+
+ENTRYPOINT ["app-entrypoint"]
+CMD ["php", "artisan", "serve", "--host=0.0.0.0", "--port=8000"]

--- a/SELF-README.md
+++ b/SELF-README.md
@@ -75,6 +75,18 @@ php artisan reverb:start --host=0.0.0.0 --port=${REVERB_PORT:-8080}
 php artisan horizon
 ```
 
+### Docker Quick Start
+
+Alternatively, you can boot the stack with Docker. Follow the detailed instructions in `docs/operations/docker-dev.md`, or run:
+
+```bash
+cp app/.env.example app/.env
+: > app/database/database.sqlite
+docker compose up --build
+```
+
+The compose file exposes the Laravel app on [http://localhost:8000](http://localhost:8000) and the Vite dev server on [http://localhost:5173](http://localhost:5173).
+
 **Vite env:**
 ```
 VITE_REVERB_APP_KEY=${REVERB_APP_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,91 @@
+version: "3.9"
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: php artisan serve --host=0.0.0.0 --port=8000
+    ports:
+      - "8000:8000"
+    environment:
+      APP_ENV: local
+      APP_DEBUG: "true"
+      APP_URL: http://localhost:8000
+      DB_CONNECTION: sqlite
+      QUEUE_CONNECTION: redis
+      CACHE_STORE: redis
+      SESSION_DRIVER: database
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      BROADCAST_CONNECTION: log
+      AUDIO_STORAGE_DISK: minio
+      RUN_MIGRATIONS: "true"
+    volumes:
+      - ./app:/var/www/html
+      - app-vendor:/var/www/html/vendor
+      - app-node-modules:/var/www/html/node_modules
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  horizon:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: php artisan horizon
+    environment:
+      APP_ENV: local
+      APP_DEBUG: "true"
+      APP_URL: http://localhost:8000
+      DB_CONNECTION: sqlite
+      QUEUE_CONNECTION: redis
+      CACHE_STORE: redis
+      SESSION_DRIVER: database
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      AUDIO_STORAGE_DISK: minio
+      RUN_MIGRATIONS: "false"
+    volumes:
+      - ./app:/var/www/html
+      - app-vendor:/var/www/html/vendor
+      - app-node-modules:/var/www/html/node_modules
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  vite:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: npm run dev -- --host 0.0.0.0 --port 5173
+    ports:
+      - "5173:5173"
+    environment:
+      APP_ENV: local
+      APP_DEBUG: "true"
+      RUN_MIGRATIONS: "false"
+    volumes:
+      - ./app:/var/www/html
+      - app-vendor:/var/www/html/vendor
+      - app-node-modules:/var/www/html/node_modules
+    depends_on:
+      app:
+        condition: service_started
+
+  redis:
+    image: redis:7.4-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    volumes:
+      - redis-data:/data
+
+volumes:
+  app-vendor:
+  app-node-modules:
+  redis-data:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /var/www/html
+
+# Ensure environment file exists
+if [ ! -f .env ]; then
+    cp .env.example .env
+fi
+
+# Ensure sqlite database file exists when using sqlite connection
+if grep -q '^DB_CONNECTION=sqlite' .env || [ "${DB_CONNECTION:-sqlite}" = "sqlite" ]; then
+    mkdir -p database
+    if [ ! -f database/database.sqlite ]; then
+        touch database/database.sqlite
+    fi
+fi
+
+# Serialise dependency installation across services
+if [ "${INSTALL_DEPENDENCIES:-true}" = "true" ]; then
+    exec 200>/.docker-deps.lock
+    flock 200
+
+    if [ ! -d vendor ]; then
+        composer install --no-interaction --prefer-dist
+    else
+        composer install --no-interaction --prefer-dist >/dev/null
+    fi
+
+    if [ -f package.json ]; then
+        if [ ! -d node_modules ]; then
+            npm install
+        fi
+    fi
+
+    flock -u 200
+fi
+
+# Generate the application key when missing
+if ! grep -q '^APP_KEY=base64:' .env; then
+    php artisan key:generate --force
+fi
+
+# Run migrations unless explicitly disabled
+if [ "${RUN_MIGRATIONS:-true}" = "true" ]; then
+    php artisan migrate --force
+fi
+
+# Ensure storage links are available
+php artisan storage:link >/dev/null 2>&1 || true
+
+exec "$@"

--- a/docs/operations/docker-dev.md
+++ b/docs/operations/docker-dev.md
@@ -1,0 +1,60 @@
+# Docker Development Environment
+
+This repository now includes a Docker Compose setup that provisions the Laravel API, Redis, Horizon queue workers, and the Vite development server. It is intended for local development so you can run the project without installing PHP, Composer, or Node.js on the host machine.
+
+## Prerequisites
+
+- Docker Engine 24+
+- Docker Compose v2 (bundled with Docker Desktop or the Docker CLI)
+
+## First-time bootstrap
+
+```bash
+# From the repository root
+cp app/.env.example app/.env
+
+# Ensure the SQLite database file exists so migrations can run
+: > app/database/database.sqlite
+
+# Build images and start the stack
+docker compose up --build
+```
+
+The first boot may take a few minutes while Composer and npm dependencies are installed. Subsequent startups reuse cached volumes.
+
+## Services
+
+| Service  | Description                                   | Exposed Ports |
+|----------|-----------------------------------------------|---------------|
+| `app`    | Laravel HTTP server (`php artisan serve`)     | 8000          |
+| `horizon`| Queue processing via Laravel Horizon          | —             |
+| `vite`   | Vite dev server for frontend assets           | 5173          |
+| `redis`  | Redis cache/queue backend                     | 6379          |
+
+Access the Laravel application at [http://localhost:8000](http://localhost:8000) and the Vite dev server at [http://localhost:5173](http://localhost:5173).
+
+## Useful commands
+
+```bash
+# Run an Artisan command
+docker compose run --rm app php artisan migrate
+
+# Install a new Composer dependency
+docker compose run --rm app composer require vendor/package
+
+# Run the PHP test suite
+docker compose run --rm app php artisan test
+
+# Install new npm packages
+docker compose run --rm vite npm install <package>
+```
+
+All application code is bind-mounted into the containers, so changes made on the host are picked up automatically.
+
+## Stopping and cleanup
+
+Press `Ctrl+C` in the terminal where `docker compose up` is running to stop the stack. To remove containers, networks, and anonymous volumes, run:
+
+```bash
+docker compose down -v
+```


### PR DESCRIPTION
## Summary
- add a PHP 8.2-based Dockerfile with a bootstrap entrypoint for Composer, npm, and database setup
- provide a docker-compose stack for the Laravel app, Horizon queue workers, the Vite dev server, and Redis
- document container usage and quick start instructions for running the project inside Docker

## Testing
- not run (Docker is not available in the execution environment)

## Migration
- `cp app/.env.example app/.env`
- `: > app/database/database.sqlite`
- `docker compose up --build`

## Rollback
- remove the Docker-related files (`Dockerfile`, `docker-compose.yml`, `.dockerignore`, `docker/entrypoint.sh`) and associated documentation

------
https://chatgpt.com/codex/tasks/task_e_68dee187aab48322a8a58c6463a1ad62