### PR TITLE
Add citation tracking to chat why card

### DIFF
--- a/app/app/Support/Chat/ChatService.php
+++ b/app/app/Support/Chat/ChatService.php
@@ -183,6 +183,7 @@ class ChatService
             'summary' => $summary,
             'memory' => [
                 'considered' => $hits->count(),
+                'citations_considered' => count($citations),
                 'used_citations' => array_column($citations, 'id'),
                 'top_scores' => $hits->take(3)->map(fn ($hit) => isset($hit['score']) ? round((float) $hit['score'], 4) : null)->filter()->values()->all(),
             ],

--- a/app/tests/Feature/Chat/ChatEndpointTest.php
+++ b/app/tests/Feature/Chat/ChatEndpointTest.php
@@ -55,6 +55,7 @@ class ChatEndpointTest extends TestCase
         $this->assertNotEmpty($payload['citations']);
         $this->assertSame($document->id, $payload['citations'][0]['document_id']);
         $this->assertSame('detailed', $payload['why_card']['detail_level']);
+        $this->assertSame(1, $payload['why_card']['memory']['citations_considered']);
         $this->assertGreaterThan(0, $payload['budget']['tokens']['limit']);
         $this->assertArrayHasKey('remaining', $payload['budget']['tokens']);
     }
@@ -88,6 +89,7 @@ class ChatEndpointTest extends TestCase
         $this->assertSame('terse', $payload['why_card']['detail_level']);
         $this->assertStringContainsString('Analyst brief', $payload['reply']);
         $this->assertStringContainsString('when you are ready', $payload['reply']);
+        $this->assertSame(1, $payload['why_card']['memory']['citations_considered']);
     }
 
     public function test_chat_blocks_high_risk_topics_and_logs_refusal(): void


### PR DESCRIPTION
## Summary
- expose the number of citations considered in the chat why card payload for milestone 3
- extend the chat feature tests to cover the new why card metric across coach and analyst modes

## Testing
- `php artisan test` *(fails: vendor directory missing in container)*

## MIGRATION
- none

## ROLLBACK
- revert this commit

------
https://chatgpt.com/codex/tasks/task_e_68dee2a69fa88322a5558a424bc9982e