### PR TITLE
Add Docker-based development workflow with make run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update \
         libsqlite3-dev \
         sqlite3 \
         supervisor \
+        python3 \
+        python3-pip \
     && docker-php-ext-configure intl \
     && docker-php-ext-install \
         bcmath \
@@ -41,6 +43,11 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 WORKDIR /var/www/html
+
+# Install Python dependencies for the embedding worker
+COPY worker-embed/requirements.txt /tmp/worker-embed-requirements.txt
+RUN pip3 install --no-cache-dir -r /tmp/worker-embed-requirements.txt \
+    && rm /tmp/worker-embed-requirements.txt
 
 # Copy application code
 COPY app/ ./

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+SHELL := /bin/bash
+DOCKER_COMPOSE ?= docker compose
+
+.PHONY: run up down stop logs build bootstrap
+
+run: up
+
+up: bootstrap
+	$(DOCKER_COMPOSE) up --build
+
+build:
+	$(DOCKER_COMPOSE) build
+
+stop down:
+	$(DOCKER_COMPOSE) down
+
+logs:
+	$(DOCKER_COMPOSE) logs -f
+
+bootstrap:
+	@if [ ! -f app/.env ]; then \
+		cp app/.env.example app/.env; \
+		printf 'Created app/.env from example.\n'; \
+	fi
+	@mkdir -p app/database
+	@if [ ! -f app/database/database.sqlite ]; then \
+		touch app/database/database.sqlite; \
+		printf 'Initialized SQLite database file at app/database/database.sqlite.\n'; \
+	fi
+	@mkdir -p app/storage/app/vector-store

--- a/SELF-README.md
+++ b/SELF-README.md
@@ -80,12 +80,10 @@ php artisan horizon
 Alternatively, you can boot the stack with Docker. Follow the detailed instructions in `docs/operations/docker-dev.md`, or run:
 
 ```bash
-cp app/.env.example app/.env
-: > app/database/database.sqlite
-docker compose up --build
+make run
 ```
 
-The compose file exposes the Laravel app on [http://localhost:8000](http://localhost:8000) and the Vite dev server on [http://localhost:5173](http://localhost:5173).
+The compose file exposes the Laravel app on [http://localhost:8000](http://localhost:8000), the Vite dev server on [http://localhost:5173](http://localhost:5173), and the verifier API on [http://localhost:8099](http://localhost:8099).
 
 **Vite env:**
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,22 @@
 version: "3.9"
 
+x-app-environment: &app-environment
+  APP_ENV: local
+  APP_DEBUG: "true"
+  APP_URL: http://localhost:8000
+  DB_CONNECTION: sqlite
+  QUEUE_CONNECTION: redis
+  CACHE_STORE: redis
+  SESSION_DRIVER: database
+  REDIS_HOST: redis
+  REDIS_PORT: 6379
+  BROADCAST_CONNECTION: log
+  AUDIO_STORAGE_DISK: minio
+  VECTOR_INDEX_KEY: "0123456789abcdef0123456789abcdef"
+  PROMOTION_VERIFIER_KEY_ID: local
+  PROMOTION_VERIFIER_KEY: dev-verifier-secret
+  RUN_MIGRATIONS: "true"
+
 services:
   app:
     build:
@@ -9,18 +26,7 @@ services:
     ports:
       - "8000:8000"
     environment:
-      APP_ENV: local
-      APP_DEBUG: "true"
-      APP_URL: http://localhost:8000
-      DB_CONNECTION: sqlite
-      QUEUE_CONNECTION: redis
-      CACHE_STORE: redis
-      SESSION_DRIVER: database
-      REDIS_HOST: redis
-      REDIS_PORT: 6379
-      BROADCAST_CONNECTION: log
-      AUDIO_STORAGE_DISK: minio
-      RUN_MIGRATIONS: "true"
+      <<: *app-environment
     volumes:
       - ./app:/var/www/html
       - app-vendor:/var/www/html/vendor
@@ -35,16 +41,7 @@ services:
       dockerfile: Dockerfile
     command: php artisan horizon
     environment:
-      APP_ENV: local
-      APP_DEBUG: "true"
-      APP_URL: http://localhost:8000
-      DB_CONNECTION: sqlite
-      QUEUE_CONNECTION: redis
-      CACHE_STORE: redis
-      SESSION_DRIVER: database
-      REDIS_HOST: redis
-      REDIS_PORT: 6379
-      AUDIO_STORAGE_DISK: minio
+      <<: *app-environment
       RUN_MIGRATIONS: "false"
     volumes:
       - ./app:/var/www/html
@@ -62,8 +59,7 @@ services:
     ports:
       - "5173:5173"
     environment:
-      APP_ENV: local
-      APP_DEBUG: "true"
+      <<: *app-environment
       RUN_MIGRATIONS: "false"
     volumes:
       - ./app:/var/www/html
@@ -72,6 +68,16 @@ services:
     depends_on:
       app:
         condition: service_started
+
+  verifier:
+    build:
+      context: verifier
+      dockerfile: Dockerfile
+    environment:
+      VERIFIER_KEY: dev-verifier-secret
+      VERIFIER_KEY_ID: local
+    ports:
+      - "8099:8099"
 
   redis:
     image: redis:7.4-alpine

--- a/docs/operations/docker-dev.md
+++ b/docs/operations/docker-dev.md
@@ -24,14 +24,15 @@ The first boot may take a few minutes while Composer and npm dependencies are in
 
 ## Services
 
-| Service  | Description                                   | Exposed Ports |
-|----------|-----------------------------------------------|---------------|
-| `app`    | Laravel HTTP server (`php artisan serve`)     | 8000          |
-| `horizon`| Queue processing via Laravel Horizon          | —             |
-| `vite`   | Vite dev server for frontend assets           | 5173          |
-| `redis`  | Redis cache/queue backend                     | 6379          |
+| Service    | Description                                         | Exposed Ports |
+|------------|-----------------------------------------------------|---------------|
+| `app`      | Laravel HTTP server (`php artisan serve`)           | 8000          |
+| `horizon`  | Queue processing via Laravel Horizon                | —             |
+| `vite`     | Vite dev server for frontend assets                 | 5173          |
+| `verifier` | FastAPI signing service for promotion workflows     | 8099          |
+| `redis`    | Redis cache/queue backend                           | 6379          |
 
-Access the Laravel application at [http://localhost:8000](http://localhost:8000) and the Vite dev server at [http://localhost:5173](http://localhost:5173).
+Access the Laravel application at [http://localhost:8000](http://localhost:8000), the Vite dev server at [http://localhost:5173](http://localhost:5173), and the verifier API at [http://localhost:8099](http://localhost:8099).
 
 ## Useful commands
 
@@ -50,6 +51,16 @@ docker compose run --rm vite npm install <package>
 ```
 
 All application code is bind-mounted into the containers, so changes made on the host are picked up automatically.
+
+## Make targets
+
+A convenience `Makefile` is available in the repository root. The fastest way to start the entire stack (including Redis and the verifier service) is:
+
+```bash
+make run
+```
+
+The `bootstrap` step runs automatically on the first invocation and ensures `.env`, the SQLite database file, and the vector store directory exist before `docker compose` is executed.
 
 ## Stopping and cleanup
 

--- a/verifier/Dockerfile
+++ b/verifier/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1.6
+
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8099
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8099"]


### PR DESCRIPTION
## Summary
- install Python tooling in the PHP image so the embedding worker can run in containers
- add a project Makefile and extend docker-compose to include the verifier service
- document the new `make run` workflow and provide a Dockerfile for the verifier API

## Testing
- python -m compileall verifier

------
https://chatgpt.com/codex/tasks/task_e_68dee31718288322aeed34736bedc397