### PR TITLE
Fix Docker build dependencies and add CI workflow

### DIFF
--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -1,0 +1,25 @@
+name: Build and Run Containers
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-and-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Bootstrap application files
+        run: make bootstrap
+
+      - name: Build and start services
+        run: docker compose up --build -d
+
+      - name: List running services
+        run: docker compose ps
+
+      - name: Tear down services
+        if: always()
+        run: docker compose down --volumes

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
         libpng-dev \
         libonig-dev \
         libxml2-dev \
+        libpq-dev \
         libsqlite3-dev \
         sqlite3 \
         supervisor \


### PR DESCRIPTION
## Summary
- install the PostgreSQL client development headers so the PHP image can compile the pdo_pgsql extension
- add a GitHub Actions workflow that bootstraps the app and ensures the docker compose stack builds and starts

## Testing
- Not run (Docker is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dee6f2cd7c8322ad2ae599558f29e2