### PR TITLE
Update embedding worker requirements for Python 3 compatibility

### DIFF
--- a/worker-embed/requirements.txt
+++ b/worker-embed/requirements.txt
@@ -1,4 +1,4 @@
-faiss-cpu==1.7.4
-numpy==1.26.4
+faiss-cpu==1.8.0
+numpy==2.3.3
 cryptography==43.0.1
 filelock==3.15.4


### PR DESCRIPTION
## Summary
- bump the embedding worker FAISS dependency to 1.8.0 to match available Python 3.12 wheels
- update the pinned numpy version to 2.3.3 to align with the newer FAISS release

## Testing
- python3 -m venv /tmp/testvenv2 && source /tmp/testvenv2/bin/activate && pip install -r worker-embed/requirements.txt

## Migration
- none

## Rollback
- revert this commit

------
https://chatgpt.com/codex/tasks/task_e_68dee884a5d08322a1e9e856e82dc6f9