### PR TITLE
Ensure Docker entrypoint installs dev dependencies

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -32,7 +32,7 @@ if [ "${INSTALL_DEPENDENCIES:-true}" = "true" ]; then
 
     if [ -f package.json ]; then
         if [ ! -d node_modules ]; then
-            npm install
+            npm install --include=dev
         fi
     fi
 


### PR DESCRIPTION
## Summary
- update the Docker entrypoint to install dev dependencies so the Vite binary is available in the container

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68def04ef0f483228af55ea773fd845d