### PR TITLE
Ensure Vite container installs dependencies when node_modules volume is empty

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -31,7 +31,7 @@ if [ "${INSTALL_DEPENDENCIES:-true}" = "true" ]; then
     fi
 
     if [ -f package.json ]; then
-        if [ ! -d node_modules ]; then
+        if [ ! -d node_modules ] || [ -z "$(find node_modules -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]; then
             npm install --include=dev
         fi
     fi


### PR DESCRIPTION
## Summary
- ensure the Docker entrypoint reruns npm install when the shared node_modules volume is empty so the Vite dev server can start

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68def1ecce308322bdc9459580cc8392