### PR TITLE
Ensure Vite container dependencies install in correct directory

### DIFF
--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -14,8 +14,14 @@ jobs:
       - name: Bootstrap application files
         run: make bootstrap
 
-      - name: Build and start services
-        run: docker compose up --build -d
+      - name: Build images
+        run: docker compose build
+
+      - name: Verify Vite build
+        run: docker compose run --rm vite pnpm run build
+
+      - name: Start services
+        run: docker compose up -d
 
       - name: List running services
         run: docker compose ps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    working_dir: /var/www/html
     command: php artisan serve --host=0.0.0.0 --port=8000
     ports:
       - "8000:8000"
@@ -39,6 +40,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    working_dir: /var/www/html
     command: php artisan horizon
     environment:
       <<: *app-environment
@@ -55,6 +57,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    working_dir: /var/www/html
     command: pnpm run dev -- --host 0.0.0.0 --port 5173
     ports:
       - "5173:5173"


### PR DESCRIPTION
## Summary
- ensure the Laravel, Horizon, and Vite services run from /var/www/html so pnpm installs dependencies in the project root
- extend the docker-compose CI workflow to build images and verify the Vite build command runs successfully before starting services

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df802f4ba08322815586e050dd905f