### PR TITLE
Add operator console frontend for API interactions

### DIFF
--- a/app/resources/js/app.js
+++ b/app/resources/js/app.js
@@ -1,1 +1,191 @@
 import './bootstrap';
+
+const escapeHtml = (value) =>
+    String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+
+const formatJson = (value) => {
+    try {
+        if (typeof value === 'string') {
+            return JSON.stringify(JSON.parse(value), null, 2);
+        }
+
+        return JSON.stringify(value, null, 2);
+    } catch (error) {
+        return typeof value === 'string' ? value : JSON.stringify(value);
+    }
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+    const container = document.getElementById('console-app');
+
+    if (!container) {
+        return;
+    }
+
+    const endpoints = (() => {
+        try {
+            return JSON.parse(container.dataset.endpoints ?? '{}');
+        } catch (error) {
+            return {};
+        }
+    })();
+
+    const state = {
+        token: container.dataset.defaultToken ?? '',
+    };
+
+    container.innerHTML = `
+        <section class="panel">
+            <h2>Authentication</h2>
+            <p>Provide a bearer token that can access the secured API endpoints.</p>
+            <label for="api-token">API token</label>
+            <input id="api-token" type="text" placeholder="sk-example-token" value="${escapeHtml(state.token)}" autocomplete="off">
+            <p style="margin-top: 0.75rem; font-size: 0.9rem; color: rgba(226, 232, 240, 0.75);">
+                The token is only used in your browser to authorise requests made from this page.
+            </p>
+        </section>
+        <section class="panel">
+            <h2>Platform health</h2>
+            <p>Ping the public health endpoint to confirm the services are reachable.</p>
+            <form id="health-form">
+                <button type="submit">Run health check</button>
+            </form>
+            <pre id="health-output">Waiting for first request…</pre>
+        </section>
+        <section class="panel">
+            <h2>Chat completions</h2>
+            <p>Send a prompt to the chat endpoint. Requires an authenticated token.</p>
+            <form id="chat-form">
+                <label for="chat-message">Prompt</label>
+                <textarea id="chat-message" rows="4" placeholder="Summarise the current on-call status"></textarea>
+                <button type="submit">Send chat request</button>
+            </form>
+            <pre id="chat-output">Waiting for first request…</pre>
+        </section>
+        <section class="panel">
+            <h2>Memory search</h2>
+            <p>Search previously ingested context with an authenticated request.</p>
+            <form id="memory-form">
+                <label for="memory-query">Search query</label>
+                <input id="memory-query" type="text" placeholder="deployment runbook" autocomplete="off">
+                <button type="submit">Search memory</button>
+            </form>
+            <pre id="memory-output">Waiting for first request…</pre>
+        </section>
+        <section class="panel">
+            <h2>Ingest text document</h2>
+            <p>Push ad-hoc context to the ingestion pipeline.</p>
+            <form id="ingest-form">
+                <label for="ingest-source">Source identifier</label>
+                <input id="ingest-source" type="text" placeholder="ops-handbook" autocomplete="off">
+                <label for="ingest-content" style="margin-top: 1rem;">Document contents</label>
+                <textarea id="ingest-content" rows="4" placeholder="Add a short note or SOP snippet"></textarea>
+                <button type="submit">Ingest text</button>
+            </form>
+            <pre id="ingest-output">Waiting for first request…</pre>
+        </section>
+    `;
+
+    const tokenInput = container.querySelector('#api-token');
+    tokenInput?.addEventListener('input', (event) => {
+        const target = event.target;
+
+        if (target instanceof HTMLInputElement) {
+            state.token = target.value;
+        }
+    });
+
+    const setOutput = (id, value) => {
+        const element = container.querySelector(id);
+
+        if (!element) {
+            return;
+        }
+
+        element.textContent = value;
+    };
+
+    const callApi = async (outputSelector, endpoint, options = {}) => {
+        if (!endpoint) {
+            setOutput(outputSelector, 'Endpoint not configured.');
+            return;
+        }
+
+        setOutput(outputSelector, '⏳ Request in flight…');
+
+        const headers = {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+            ...options.headers,
+        };
+
+        const token = state.token.trim();
+        if (token.length > 0) {
+            headers.Authorization = `Bearer ${token}`;
+        }
+
+        const requestInit = {
+            method: 'GET',
+            ...options,
+            headers,
+        };
+
+        try {
+            const response = await fetch(endpoint, requestInit);
+            const text = await response.text();
+            const payload = formatJson(text);
+            setOutput(outputSelector, `${response.status} ${response.statusText}\n\n${payload}`);
+        } catch (error) {
+            setOutput(outputSelector, `Request failed: ${error.message}`);
+        }
+    };
+
+    container.querySelector('#health-form')?.addEventListener('submit', (event) => {
+        event.preventDefault();
+        callApi('#health-output', endpoints.health, { method: 'GET' });
+    });
+
+    container.querySelector('#chat-form')?.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const body = {
+            messages: [
+                {
+                    role: 'user',
+                    content: container.querySelector('#chat-message')?.value ?? '',
+                },
+            ],
+        };
+
+        callApi('#chat-output', endpoints.chat, {
+            method: 'POST',
+            body: JSON.stringify(body),
+        });
+    });
+
+    container.querySelector('#memory-form')?.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const query = container.querySelector('#memory-query')?.value ?? '';
+        const endpoint = endpoints.memorySearch ? `${endpoints.memorySearch}?q=${encodeURIComponent(query)}` : undefined;
+
+        callApi('#memory-output', endpoint, { method: 'GET' });
+    });
+
+    container.querySelector('#ingest-form')?.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const body = {
+            source: container.querySelector('#ingest-source')?.value ?? '',
+            document: container.querySelector('#ingest-content')?.value ?? '',
+        };
+
+        callApi('#ingest-output', endpoints.ingestText, {
+            method: 'POST',
+            body: JSON.stringify(body),
+        });
+    });
+});

--- a/app/resources/views/console.blade.php
+++ b/app/resources/views/console.blade.php
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
+
+        <title>{{ config('app.name', 'Self AI') }} Console</title>
+
+        <link rel="preconnect" href="https://fonts.bunny.net">
+        <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
+
+        @if (file_exists(public_path('build/manifest.json')) || file_exists(public_path('hot')))
+            @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @else
+            <style>
+                :root {
+                    color-scheme: light dark;
+                }
+
+                body {
+                    font-family: 'Instrument Sans', sans-serif;
+                    margin: 0;
+                    background: #0f172a;
+                    color: #f8fafc;
+                    min-height: 100vh;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    padding: 1.5rem;
+                }
+
+                main {
+                    width: min(960px, 100%);
+                    background: rgba(15, 23, 42, 0.85);
+                    border-radius: 1.5rem;
+                    padding: 2.5rem;
+                    box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.9);
+                    backdrop-filter: blur(12px);
+                }
+
+                h1 {
+                    font-size: clamp(2rem, 5vw, 2.75rem);
+                    margin-bottom: 0.5rem;
+                }
+
+                p.description {
+                    margin-top: 0;
+                    margin-bottom: 2rem;
+                    color: rgba(226, 232, 240, 0.85);
+                }
+
+                #console-app {
+                    display: grid;
+                    gap: 1.5rem;
+                }
+
+                .panel {
+                    border: 1px solid rgba(148, 163, 184, 0.25);
+                    border-radius: 1rem;
+                    padding: 1.5rem;
+                    background: rgba(30, 41, 59, 0.75);
+                }
+
+                label {
+                    display: block;
+                    font-weight: 600;
+                    margin-bottom: 0.75rem;
+                }
+
+                input[type="text"],
+                input[type="url"],
+                textarea {
+                    width: 100%;
+                    border-radius: 0.75rem;
+                    border: 1px solid rgba(148, 163, 184, 0.4);
+                    background: rgba(15, 23, 42, 0.65);
+                    color: inherit;
+                    padding: 0.75rem 1rem;
+                    font-size: 1rem;
+                    resize: vertical;
+                }
+
+                button {
+                    display: inline-flex;
+                    align-items: center;
+                    gap: 0.5rem;
+                    border-radius: 9999px;
+                    border: none;
+                    padding: 0.65rem 1.25rem;
+                    font-weight: 600;
+                    cursor: pointer;
+                    background: linear-gradient(120deg, #22d3ee, #6366f1);
+                    color: #0f172a;
+                }
+
+                pre {
+                    background: rgba(15, 23, 42, 0.65);
+                    border-radius: 1rem;
+                    padding: 1rem;
+                    font-size: 0.9rem;
+                    overflow: auto;
+                    max-height: 320px;
+                }
+            </style>
+        @endif
+    </head>
+    <body>
+        <main>
+            <h1>Self AI Operator Console</h1>
+            <p class="description">
+                Use this lightweight console to call the platform APIs for health checks, chat completions, memory searches, and document ingestion.
+                Provide an API token that has access to the relevant scopes to issue authenticated requests.
+            </p>
+            <div id="console-app"
+                data-endpoints='@json($apiEndpoints)'
+                data-default-token=""
+                class="console-grid">
+                <noscript>This console requires JavaScript.</noscript>
+            </div>
+        </main>
+    </body>
+</html>

--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -7,6 +7,17 @@ Route::get('/', function () {
     return view('welcome');
 });
 
+Route::get('/console', function () {
+    return view('console', [
+        'apiEndpoints' => [
+            'health' => url('/api/health'),
+            'chat' => url('/api/v1/chat'),
+            'memorySearch' => url('/api/v1/memory/search'),
+            'ingestText' => url('/api/v1/ingest/text'),
+        ],
+    ]);
+})->name('console');
+
 Route::middleware('auth')->prefix('review/documents')->name('review.documents.')->group(function (): void {
     Route::get('/', [ReviewDocumentController::class, 'index'])->name('index');
     Route::post('/{document}/approve', [ReviewDocumentController::class, 'approve'])->name('approve');

--- a/app/tests/Feature/Frontend/ConsoleFrontendTest.php
+++ b/app/tests/Feature/Frontend/ConsoleFrontendTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature\Frontend;
+
+use App\Support\Observability\MetricCollector;
+use DOMDocument;
+use Tests\TestCase;
+
+class ConsoleFrontendTest extends TestCase
+{
+    public function test_console_page_renders_with_api_endpoints(): void
+    {
+        $response = $this->get('/console');
+
+        $response->assertOk();
+
+        $dom = new DOMDocument();
+        $dom->preserveWhiteSpace = false;
+        @$dom->loadHTML($response->getContent());
+
+        $element = $dom->getElementById('console-app');
+        $this->assertNotNull($element);
+
+        $payload = json_decode($element->getAttribute('data-endpoints') ?? '{}', true);
+        $this->assertIsArray($payload);
+        $this->assertSame(url('/api/health'), $payload['health'] ?? null);
+        $this->assertSame(url('/api/v1/chat'), $payload['chat'] ?? null);
+        $this->assertSame(url('/api/v1/memory/search'), $payload['memorySearch'] ?? null);
+        $this->assertSame(url('/api/v1/ingest/text'), $payload['ingestText'] ?? null);
+    }
+
+    public function test_console_can_reach_health_endpoint(): void
+    {
+        app()->instance(MetricCollector::class, new class extends MetricCollector {
+            /**
+             * @return array<string, mixed>
+             */
+            public function snapshot(): array
+            {
+                return [
+                    'collected_at' => now()->toIso8601String(),
+                    'queues' => [
+                        ['name' => 'default', 'depth' => 0, 'status' => 'ok'],
+                    ],
+                    'gpu' => ['status' => 'unavailable'],
+                    'refusals' => ['window_hours' => 24, 'count' => 0],
+                ];
+            }
+        });
+
+        $response = $this->getJson('/api/health');
+
+        $response->assertOk();
+        $response->assertJsonPath('status', 'ok');
+        $response->assertJsonStructure([
+            'status',
+            'timestamp',
+            'app',
+            'queue',
+            'policy_hash',
+            'policy_version',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add a /console web route that serves an operator console view with API endpoint metadata
- build a lightweight frontend console that can call health, chat, memory search, and ingestion services
- cover the console with feature tests that parse exposed endpoints and verify health access via a stubbed metric collector

## Testing
- php artisan test --filter=ConsoleFrontendTest

------
https://chatgpt.com/codex/tasks/task_e_68e4c6ea99fc832289bc4bacea30dc08